### PR TITLE
Rework experiment status upload to per-row model (#66)

### DIFF
--- a/backend/api/routers/bulk_uploads.py
+++ b/backend/api/routers/bulk_uploads.py
@@ -984,11 +984,58 @@ def _get_template_bytes(upload_type: str, mode: Optional[str] = None) -> bytes:
         )
 
     if upload_type == "experiment-status":
-        return _simple_template(
-            headers=["experiment_id", "reactor_number"],
-            required={"experiment_id"},
-            example_row=["HPHT_072", 3],
-        )
+        import openpyxl  # noqa: PLC0415
+        from openpyxl.styles import PatternFill, Font, Alignment  # noqa: PLC0415
+
+        headers = ["experiment_id", "status", "reactor_number", "date"]
+        required = {"experiment_id", "status"}
+        example_row = ["HPHT_072", "ONGOING", 3, "2026-07-15"]
+        req_fill = PatternFill(start_color="FFD700", end_color="FFD700", fill_type="solid")
+        opt_fill = PatternFill(start_color="E2EFDA", end_color="E2EFDA", fill_type="solid")
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Template"
+        for col, h in enumerate(headers, start=1):
+            cell = ws.cell(row=1, column=col, value=h)
+            cell.font = Font(bold=True)
+            cell.fill = req_fill if h in required else opt_fill
+            cell.alignment = Alignment(horizontal="center")
+            ws.column_dimensions[cell.column_letter].width = max(len(h) + 4, 18)
+        for col, val in enumerate(example_row, start=1):
+            ws.cell(row=2, column=col, value=val)
+
+        ws_inst = wb.create_sheet("INSTRUCTIONS")
+        ws_inst.column_dimensions["A"].width = 30
+        ws_inst.column_dimensions["B"].width = 80
+        instructions = [
+            ("Column", "Notes"),
+            ("experiment_id", "REQUIRED. Must match an existing experiment_id."),
+            ("status", "REQUIRED. One of ONGOING, COMPLETED, CANCELLED, QUEUED (case-insensitive)."),
+            ("reactor_number", "Integer. Only meaningful for HPHT / Core Flood experiments."),
+            (
+                "date",
+                "Experiment start date (YYYY-MM-DD or Excel date). Used both to set the "
+                "experiment's start date and to decide reactor demotion order.",
+            ),
+            (
+                "Demotion rule",
+                "Setting an HPHT or Core Flood experiment to ONGOING with a reactor_number "
+                "completes an older experiment currently ongoing in the same reactor. If the "
+                "reactor is held by a newer-or-equal-dated experiment (or either start date "
+                "is missing), nothing is demoted and a warning is returned.",
+            ),
+        ]
+        for r_idx, (col_name, note) in enumerate(instructions, start=1):
+            name_cell = ws_inst.cell(row=r_idx, column=1, value=col_name)
+            note_cell = ws_inst.cell(row=r_idx, column=2, value=note)
+            if r_idx == 1:
+                name_cell.font = Font(bold=True)
+                note_cell.font = Font(bold=True)
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        return buf.getvalue()
 
     raise ValueError(f"Unknown template type: {upload_type}")
 

--- a/backend/api/routers/bulk_uploads.py
+++ b/backend/api/routers/bulk_uploads.py
@@ -583,7 +583,7 @@ async def upload_experiment_status(
     db: Session = Depends(get_db),
     current_user: FirebaseUser = Depends(verify_firebase_token),
 ) -> UploadResponse:
-    """Upload an Experiment Status Excel file (bulk ONGOING / COMPLETED changes)."""
+    """Upload an Experiment Status Excel file (per-row status/date/reactor updates)."""
     from backend.services.bulk_uploads.experiment_status import ExperimentStatusService  # noqa: PLC0415
     file_bytes = await file.read()
     try:
@@ -594,16 +594,8 @@ async def upload_experiment_status(
                 errors=preview.errors,
                 message="Validation failed — no changes applied",
             )
-        to_ongoing_ids = [item["experiment_id"] for item in preview.to_ongoing]
-        reactor_map = {
-            item["experiment_id"]: item["new_reactor_number"]
-            for item in preview.to_ongoing
-            if item.get("new_reactor_number") is not None
-        }
-        marked_ongoing, marked_completed, _reactor_updates, errors = (
-            ExperimentStatusService.apply_status_changes(db, to_ongoing_ids, reactor_map)
-        )
-        if not errors:
+        result = ExperimentStatusService.apply_status_changes(db, preview)
+        if not result.errors:
             db.commit()
         else:
             db.rollback()
@@ -612,16 +604,22 @@ async def upload_experiment_status(
         log.error("experiment_status_upload_failed", error=str(exc))
         return UploadResponse(created=0, updated=0, skipped=0, errors=[str(exc)],
                               message="Upload failed")
-    total = marked_ongoing + marked_completed
     return UploadResponse(
-        created=0, updated=total, skipped=len(preview.missing_ids),
-        errors=errors,
-        feedbacks=[
-            {"marked_ongoing": marked_ongoing, "marked_completed": marked_completed}
-        ],
+        created=0,
+        updated=result.status_changes_applied,
+        skipped=len(preview.missing_ids),
+        errors=result.errors,
+        warnings=result.warnings,
+        feedbacks=[{
+            "status_changes": result.status_changes_applied,
+            "demotions": result.demotions_applied,
+            "reactor_updates": result.reactor_updates,
+            "date_updates": result.date_updates,
+        }],
         message=(
-            f"Status update: {marked_ongoing} → ONGOING, "
-            f"{marked_completed} → COMPLETED, {len(preview.missing_ids)} not found"
+            f"Status update: {result.status_changes_applied} row(s) applied, "
+            f"{result.demotions_applied} reactor demotion(s), "
+            f"{len(preview.missing_ids)} not found"
         ),
     )
 

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 from datetime import datetime
-from typing import List, Tuple, Dict, Any
+from typing import List, Any
 from dataclasses import dataclass
 
 import pandas as pd
@@ -80,6 +80,17 @@ class StatusChangePreview:
     missing_ids: List[str]
     errors: List[str]
     warnings: List[str]
+
+
+@dataclass
+class ApplyResult:
+    """Outcome of applying a StatusChangePreview."""
+    status_changes_applied: int
+    demotions_applied: int
+    reactor_updates: int
+    date_updates: int
+    warnings: List[str]
+    errors: List[str]
 
 
 class ExperimentStatusService:
@@ -259,66 +270,77 @@ class ExperimentStatusService:
     @staticmethod
     def apply_status_changes(
         db: Session,
-        experiment_ids_to_ongoing: List[str],
-        reactor_number_map: Dict[str, int] = None
-    ) -> Tuple[int, int, int, List[str]]:
+        preview: StatusChangePreview,
+    ) -> ApplyResult:
         """
-        Apply status changes: set listed experiments to ONGOING, others to COMPLETED.
-        Optionally update reactor numbers.
-        
+        Apply a StatusChangePreview: set each row's status/date/reactor_number,
+        then run reactor-occupancy demotion for eligible ONGOING rows.
+
         Args:
             db: Database session
-            experiment_ids_to_ongoing: List of experiment IDs to mark as ONGOING
-            reactor_number_map: Optional dict mapping experiment_id to reactor_number
-            
+            preview: The StatusChangePreview returned by preview_status_changes_from_excel
+
         Returns:
-            Tuple of (marked_ongoing_count, marked_completed_count, reactor_updates_count, errors)
+            ApplyResult with counts and any warnings/errors encountered.
         """
         errors: List[str] = []
-        marked_ongoing = 0
-        marked_completed = 0
+        warnings: List[str] = []
+        status_changes = 0
+        date_updates = 0
         reactor_updates = 0
-        reactor_number_map = reactor_number_map or {}
-        
+        demotions_applied = 0
+
         try:
-            # Update experiments to ONGOING and update reactor numbers
-            if experiment_ids_to_ongoing:
-                to_ongoing_exps = db.query(Experiment).outerjoin(
-                    ExperimentalConditions,
-                    Experiment.id == ExperimentalConditions.experiment_fk
-                ).filter(
-                    Experiment.experiment_id.in_(experiment_ids_to_ongoing)
-                ).all()
-                
-                for exp in to_ongoing_exps:
-                    exp.status = ExperimentStatus.ONGOING
-                    marked_ongoing += 1
-                    
-                    # Update reactor_number if provided
-                    if exp.experiment_id in reactor_number_map and exp.conditions:
-                        new_reactor_number = reactor_number_map[exp.experiment_id]
-                        if exp.conditions.reactor_number != new_reactor_number:
-                            exp.conditions.reactor_number = new_reactor_number
-                            reactor_updates += 1
-            
-            # Update other ONGOING HPHT experiments to COMPLETED
-            to_completed_exps = db.query(Experiment).join(
+            exp_ids = [c.experiment_id for c in preview.changes]
+            exps = db.query(Experiment).outerjoin(
                 ExperimentalConditions,
-                Experiment.id == ExperimentalConditions.experiment_fk
-            ).filter(
-                Experiment.status == ExperimentStatus.ONGOING,
-                ExperimentalConditions.experiment_type == "HPHT",
-                ~Experiment.experiment_id.in_(experiment_ids_to_ongoing) if experiment_ids_to_ongoing else True
-            ).all()
-            
-            for exp in to_completed_exps:
-                exp.status = ExperimentStatus.COMPLETED
-                marked_completed += 1
-            
+                Experiment.id == ExperimentalConditions.experiment_fk,
+            ).filter(Experiment.experiment_id.in_(exp_ids)).all() if exp_ids else []
+            exp_by_id = {e.experiment_id: e for e in exps}
+
+            for change in preview.changes:
+                exp = exp_by_id.get(change.experiment_id)
+                if exp is None:
+                    continue
+
+                exp.status = ExperimentStatus(change.new_status)
+                status_changes += 1
+
+                if change.new_date is not None:
+                    exp.date = change.new_date.to_pydatetime()
+                    date_updates += 1
+
+                if change.new_reactor_number is not None and exp.conditions:
+                    if exp.conditions.reactor_number != change.new_reactor_number:
+                        exp.conditions.reactor_number = change.new_reactor_number
+                        reactor_updates += 1
+
+                if (
+                    change.new_status == ExperimentStatus.ONGOING.value
+                    and change.new_reactor_number is not None
+                    and _is_eligible_for_occupancy(change.experiment_type)
+                ):
+                    newer_than = change.new_date.to_pydatetime() if change.new_date is not None else None
+                    marked, occ_warnings = ExperimentStatusService.manage_reactor_occupancy(
+                        db, exp, change.new_reactor_number, commit=False, newer_than=newer_than,
+                    )
+                    demotions_applied += marked
+                    warnings.extend(occ_warnings)
+
+            db.commit()
+
         except Exception as e:
             errors.append(f"Error applying status changes: {e}")
-        
-        return marked_ongoing, marked_completed, reactor_updates, errors
+            db.rollback()
+
+        return ApplyResult(
+            status_changes_applied=status_changes,
+            demotions_applied=demotions_applied,
+            reactor_updates=reactor_updates,
+            date_updates=date_updates,
+            warnings=warnings,
+            errors=errors,
+        )
     
     @staticmethod
     def manage_reactor_occupancy(

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -196,7 +196,7 @@ class ExperimentStatusService:
             return StatusChangePreview([], [], missing_ids, conflict_errors, [])
 
         return StatusChangePreview(changes, [], missing_ids, [], [])
-
+    
     @staticmethod
     def apply_status_changes(
         db: Session,
@@ -206,12 +206,12 @@ class ExperimentStatusService:
         """
         Apply status changes: set listed experiments to ONGOING, others to COMPLETED.
         Optionally update reactor numbers.
-
+        
         Args:
             db: Database session
             experiment_ids_to_ongoing: List of experiment IDs to mark as ONGOING
             reactor_number_map: Optional dict mapping experiment_id to reactor_number
-
+            
         Returns:
             Tuple of (marked_ongoing_count, marked_completed_count, reactor_updates_count, errors)
         """
@@ -220,7 +220,7 @@ class ExperimentStatusService:
         marked_completed = 0
         reactor_updates = 0
         reactor_number_map = reactor_number_map or {}
-
+        
         try:
             # Update experiments to ONGOING and update reactor numbers
             if experiment_ids_to_ongoing:
@@ -230,18 +230,18 @@ class ExperimentStatusService:
                 ).filter(
                     Experiment.experiment_id.in_(experiment_ids_to_ongoing)
                 ).all()
-
+                
                 for exp in to_ongoing_exps:
                     exp.status = ExperimentStatus.ONGOING
                     marked_ongoing += 1
-
+                    
                     # Update reactor_number if provided
                     if exp.experiment_id in reactor_number_map and exp.conditions:
                         new_reactor_number = reactor_number_map[exp.experiment_id]
                         if exp.conditions.reactor_number != new_reactor_number:
                             exp.conditions.reactor_number = new_reactor_number
                             reactor_updates += 1
-
+            
             # Update other ONGOING HPHT experiments to COMPLETED
             to_completed_exps = db.query(Experiment).join(
                 ExperimentalConditions,
@@ -251,16 +251,16 @@ class ExperimentStatusService:
                 ExperimentalConditions.experiment_type == "HPHT",
                 ~Experiment.experiment_id.in_(experiment_ids_to_ongoing) if experiment_ids_to_ongoing else True
             ).all()
-
+            
             for exp in to_completed_exps:
                 exp.status = ExperimentStatus.COMPLETED
                 marked_completed += 1
-
+            
         except Exception as e:
             errors.append(f"Error applying status changes: {e}")
-
+        
         return marked_ongoing, marked_completed, reactor_updates, errors
-
+    
     @staticmethod
     def manage_reactor_occupancy(
         db: Session,
@@ -270,19 +270,19 @@ class ExperimentStatusService:
     ) -> Tuple[int, List[str]]:
         """
         Ensure only one experiment is ONGOING per reactor at a time.
-
+        
         When a new experiment is set to ONGOING with a reactor number, this function
         automatically marks any other ONGOING experiments in the same reactor as COMPLETED.
-
+        
         Args:
             db: Database session
             new_experiment: The experiment being created/updated
             reactor_number: The reactor number being assigned
             commit: Whether to commit changes (default True)
-
+            
         Returns:
             Tuple of (marked_completed_count, warnings)
-
+            
         Example:
             >>> marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
             ...     db, new_exp, reactor_number=3
@@ -291,12 +291,12 @@ class ExperimentStatusService:
         """
         warnings: List[str] = []
         marked_completed = 0
-
+        
         try:
             # Only manage occupancy if the new experiment is ONGOING
             if new_experiment.status != ExperimentStatus.ONGOING:
                 return 0, []
-
+            
             # Find other ONGOING experiments in the same reactor
             conflicting_experiments = db.query(Experiment).join(
                 ExperimentalConditions,
@@ -306,7 +306,7 @@ class ExperimentStatusService:
                 Experiment.status == ExperimentStatus.ONGOING,
                 ExperimentalConditions.reactor_number == reactor_number
             ).all()
-
+            
             # Mark conflicting experiments as COMPLETED
             for exp in conflicting_experiments:
                 exp.status = ExperimentStatus.COMPLETED
@@ -315,13 +315,13 @@ class ExperimentStatusService:
                     f"Reactor {reactor_number}: Marked experiment '{exp.experiment_id}' "
                     f"as COMPLETED (replaced by '{new_experiment.experiment_id}')"
                 )
-
+            
             if commit:
                 db.commit()
-
+                
         except Exception as e:
             warnings.append(f"Error managing reactor occupancy: {e}")
             if commit:
                 db.rollback()
-
+        
         return marked_completed, warnings

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from datetime import datetime
+from datetime import datetime, date
 from typing import List, Tuple, Dict, Any
 from dataclasses import dataclass
 
@@ -28,7 +28,7 @@ def _is_eligible_for_occupancy(experiment_type: str | None) -> bool:
     return _normalize_type(experiment_type) in _OCCUPANCY_TYPES
 
 
-def _occupant_is_older(occupant_date, incoming_date) -> bool:
+def _occupant_is_older(occupant_date: date | None, incoming_date: date | None) -> bool:
     """True only when both dates are present and the occupant started strictly earlier."""
     if occupant_date is None or incoming_date is None:
         return False

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from datetime import datetime
 from typing import List, Tuple, Dict, Any
 from dataclasses import dataclass
 
@@ -14,6 +15,7 @@ from database.models.enums import ExperimentStatus
 
 _VALID_STATUSES = {s.value for s in ExperimentStatus}
 _OCCUPANCY_TYPES = {"hpht", "core flood"}
+_UNSET = object()
 
 
 def _normalize_type(experiment_type: str | None) -> str:
@@ -323,63 +325,74 @@ class ExperimentStatusService:
         db: Session,
         new_experiment: Experiment,
         reactor_number: int,
-        commit: bool = True
+        commit: bool = True,
+        newer_than: datetime | None = _UNSET,
     ) -> Tuple[int, List[str]]:
         """
         Ensure only one experiment is ONGOING per reactor at a time.
-        
+
         When a new experiment is set to ONGOING with a reactor number, this function
-        automatically marks any other ONGOING experiments in the same reactor as COMPLETED.
-        
+        marks other ONGOING experiments in the same reactor as COMPLETED.
+
+        If `newer_than` is explicitly passed (even as None), a start-date guard is
+        active: an occupant is only demoted if its `date` is strictly older (by
+        calendar date) than `newer_than`; occupants with a missing date, or a date
+        that is newer-or-equal, are left ONGOING with a warning instead. Omitting
+        `newer_than` entirely preserves the original unconditional behavior relied
+        on by `new_experiments.py` and the legacy create path.
+
         Args:
             db: Database session
             new_experiment: The experiment being created/updated
             reactor_number: The reactor number being assigned
             commit: Whether to commit changes (default True)
-            
+            newer_than: Optional start-date guard (see above)
+
         Returns:
             Tuple of (marked_completed_count, warnings)
-            
-        Example:
-            >>> marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
-            ...     db, new_exp, reactor_number=3
-            ... )
-            >>> print(f"Marked {marked} experiments as completed")
         """
         warnings: List[str] = []
         marked_completed = 0
-        
+        guard_active = newer_than is not _UNSET
+
         try:
-            # Only manage occupancy if the new experiment is ONGOING
             if new_experiment.status != ExperimentStatus.ONGOING:
                 return 0, []
-            
-            # Find other ONGOING experiments in the same reactor
+
             conflicting_experiments = db.query(Experiment).join(
                 ExperimentalConditions,
                 Experiment.id == ExperimentalConditions.experiment_fk
             ).filter(
-                Experiment.id != new_experiment.id,  # Exclude the current experiment
+                Experiment.id != new_experiment.id,
                 Experiment.status == ExperimentStatus.ONGOING,
                 ExperimentalConditions.reactor_number == reactor_number
             ).all()
-            
-            # Mark conflicting experiments as COMPLETED
+
             for exp in conflicting_experiments:
+                if guard_active:
+                    occ_date = exp.date.date() if exp.date else None
+                    incoming_date = newer_than.date() if newer_than else None
+                    if incoming_date is None or occ_date is None or occ_date >= incoming_date:
+                        warnings.append(
+                            _not_demoted_message(reactor_number, exp.experiment_id, new_experiment.experiment_id)
+                        )
+                        continue
+
                 exp.status = ExperimentStatus.COMPLETED
                 marked_completed += 1
                 warnings.append(
-                    f"Reactor {reactor_number}: Marked experiment '{exp.experiment_id}' "
-                    f"as COMPLETED (replaced by '{new_experiment.experiment_id}')"
+                    _demoted_message(reactor_number, exp.experiment_id, new_experiment.experiment_id)
                 )
-            
+
             if commit:
                 db.commit()
-                
+            else:
+                db.flush()
+
         except Exception as e:
             warnings.append(f"Error managing reactor occupancy: {e}")
             if commit:
                 db.rollback()
-        
+
         return marked_completed, warnings
 

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -325,3 +325,4 @@ class ExperimentStatusService:
                 db.rollback()
         
         return marked_completed, warnings
+

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 from datetime import datetime
-from typing import List, Any
+from typing import List, Tuple, Dict, Any
 from dataclasses import dataclass
 
 import pandas as pd
@@ -327,11 +327,10 @@ class ExperimentStatusService:
                     demotions_applied += marked
                     warnings.extend(occ_warnings)
 
-            db.commit()
+            db.flush()
 
         except Exception as e:
             errors.append(f"Error applying status changes: {e}")
-            db.rollback()
 
         return ApplyResult(
             status_changes_applied=status_changes,

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -12,143 +12,191 @@ from database.models import ExperimentalConditions
 from database.models.enums import ExperimentStatus
 
 
+_VALID_STATUSES = {s.value for s in ExperimentStatus}
+_OCCUPANCY_TYPES = {"hpht", "core flood"}
+
+
+def _normalize_type(experiment_type: str | None) -> str:
+    """Lowercase + collapse whitespace so 'HPHT ', 'Core  Flood', etc. compare cleanly."""
+    return " ".join((experiment_type or "").strip().lower().split())
+
+
+def _is_eligible_for_occupancy(experiment_type: str | None) -> bool:
+    """True for HPHT / Core Flood — the types with physical reactor occupancy."""
+    return _normalize_type(experiment_type) in _OCCUPANCY_TYPES
+
+
+@dataclass
+class PlannedChange:
+    """One row's planned effect on an Experiment."""
+    experiment_id: str
+    experiment_pk: int
+    current_status: str
+    new_status: str
+    experiment_type: str | None
+    reactor_number: int | None       # current ExperimentalConditions.reactor_number
+    new_reactor_number: int | None   # value from the row, if provided
+    new_date: pd.Timestamp | None    # value from the row, if provided
+
+
+@dataclass
+class PlannedDemotion:
+    """One reactor occupant that will be completed when its row's demotion is applied."""
+    experiment_id: str
+    experiment_pk: int
+    reactor_number: int
+    triggering_experiment_id: str
+
+
 @dataclass
 class StatusChangePreview:
-    """Preview of status changes to be applied"""
-    to_ongoing: List[Dict[str, Any]]  # List of {experiment_id, current_status, reactor_number, new_reactor_number}
-    to_completed: List[Dict[str, Any]]  # List of {experiment_id, current_status, reactor_number}
-    missing_ids: List[str]  # Experiment IDs not found in database
-    errors: List[str]  # Validation errors
+    """Preview of per-row status changes and reactor demotions to be applied."""
+    changes: List[PlannedChange]
+    demotions: List[PlannedDemotion]
+    missing_ids: List[str]
+    errors: List[str]
+    warnings: List[str]
 
 
 class ExperimentStatusService:
     """Service for bulk updating experiment statuses"""
-    
+
     @staticmethod
     def preview_status_changes_from_excel(
-        db: Session, 
-        file_bytes: bytes
+        db: Session,
+        file_bytes: bytes,
     ) -> StatusChangePreview:
         """
-        Preview status changes from an Excel file.
-        
+        Preview per-row status/date/reactor changes from an Excel file.
+
         Args:
             db: Database session
-            file_bytes: Excel file bytes with 'experiment_id' (required) and 
-                       'reactor_number' (optional) columns
-            
+            file_bytes: Excel file bytes with 'experiment_id' (required), 'status'
+                       (required), 'reactor_number' (optional), 'date' (optional) columns
+
         Returns:
-            StatusChangePreview with lists of changes to be made, including 
-            reactor_number_map attribute for applying reactor number updates
+            StatusChangePreview with planned per-row changes, planned reactor
+            demotions, missing experiment IDs, row/column-level errors, and warnings.
         """
-        errors: List[str] = []
-        missing_ids: List[str] = []
-        
-        # Read Excel file
         try:
             df = pd.read_excel(io.BytesIO(file_bytes))
         except Exception as e:
-            return StatusChangePreview(
-                to_ongoing=[],
-                to_completed=[],
-                missing_ids=[],
-                errors=[f"Failed to read Excel: {e}"]
-            )
-        
-        # Normalize column names (case-insensitive)
+            return StatusChangePreview([], [], [], [f"Failed to read Excel: {e}"], [])
+
         col_map = {str(c).lower().strip(): str(c) for c in df.columns}
-        
-        # Check for required column
+
         if "experiment_id" not in col_map:
-            return StatusChangePreview(
-                to_ongoing=[],
-                to_completed=[],
-                missing_ids=[],
-                errors=["Missing required column: 'experiment_id'"]
-            )
-        
-        # Rename to standard column names
-        rename_map = {col_map["experiment_id"]: "experiment_id"}
+            return StatusChangePreview([], [], [], ["Missing required column: 'experiment_id'"], [])
+        if "status" not in col_map:
+            return StatusChangePreview([], [], [], ["Missing required column: 'status'"], [])
+
+        rename_map = {col_map["experiment_id"]: "experiment_id", col_map["status"]: "status"}
         if "reactor_number" in col_map:
             rename_map[col_map["reactor_number"]] = "reactor_number"
+        if "date" in col_map:
+            rename_map[col_map["date"]] = "date"
         df = df.rename(columns=rename_map)
-        
-        # Extract experiment IDs and reactor numbers (remove blanks and duplicates)
-        listed_exp_ids = []
-        reactor_number_map = {}  # Maps experiment_id to reactor_number
-        for idx, row in df.iterrows():
+
+        errors: List[str] = []
+        parsed_rows: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+
+        for _, row in df.iterrows():
             exp_id = str(row.get("experiment_id") or "").strip()
-            if exp_id and exp_id not in listed_exp_ids:
-                listed_exp_ids.append(exp_id)
-                # Store reactor_number if provided and valid
-                if "reactor_number" in df.columns:
-                    reactor_val = row.get("reactor_number")
-                    if pd.notna(reactor_val):
-                        try:
-                            reactor_number_map[exp_id] = int(reactor_val)
-                        except (ValueError, TypeError):
-                            errors.append(f"Invalid reactor_number for {exp_id}: {reactor_val}")
-        
-        if not listed_exp_ids:
-            return StatusChangePreview(
-                to_ongoing=[],
-                to_completed=[],
-                missing_ids=[],
-                errors=["No valid experiment IDs found in file"]
-            )
-        
-        # Find experiments to set ONGOING (must exist in DB) with their conditions
-        to_ongoing_exps = db.query(Experiment).outerjoin(
+            if not exp_id or exp_id in seen_ids:
+                continue
+            seen_ids.add(exp_id)
+
+            row_errors: List[str] = []
+
+            raw_status = row.get("status")
+            status_str = str(raw_status).strip().upper() if pd.notna(raw_status) else ""
+            if status_str not in _VALID_STATUSES:
+                row_errors.append(f"Invalid status for {exp_id}: {raw_status!r}")
+
+            reactor_number = None
+            if "reactor_number" in df.columns:
+                reactor_val = row.get("reactor_number")
+                if pd.notna(reactor_val):
+                    try:
+                        reactor_number = int(reactor_val)
+                    except (ValueError, TypeError):
+                        row_errors.append(f"Invalid reactor_number for {exp_id}: {reactor_val}")
+
+            new_date = None
+            if "date" in df.columns:
+                date_val = row.get("date")
+                if pd.notna(date_val):
+                    try:
+                        new_date = pd.Timestamp(date_val)
+                    except (ValueError, TypeError):
+                        row_errors.append(f"Invalid date for {exp_id}: {date_val}")
+
+            if row_errors:
+                errors.extend(row_errors)
+                continue
+
+            parsed_rows.append({
+                "experiment_id": exp_id,
+                "status": status_str,
+                "reactor_number": reactor_number,
+                "date": new_date,
+            })
+
+        if not parsed_rows and not errors:
+            return StatusChangePreview([], [], [], ["No valid experiment IDs found in file"], [])
+        if errors:
+            return StatusChangePreview([], [], [], errors, [])
+
+        listed_ids = [r["experiment_id"] for r in parsed_rows]
+        exps = db.query(Experiment).outerjoin(
             ExperimentalConditions,
-            Experiment.id == ExperimentalConditions.experiment_fk
-        ).filter(
-            Experiment.experiment_id.in_(listed_exp_ids)
-        ).all()
-        
-        # Track which IDs were found
-        found_ids = {exp.experiment_id for exp in to_ongoing_exps}
-        missing_ids = [exp_id for exp_id in listed_exp_ids if exp_id not in found_ids]
-        
-        # Find experiments to set COMPLETED (currently ONGOING, not in list, and HPHT type)
-        to_completed_exps = db.query(Experiment).join(
-            ExperimentalConditions,
-            Experiment.id == ExperimentalConditions.experiment_fk
-        ).filter(
-            Experiment.status == ExperimentStatus.ONGOING,
-            ~Experiment.experiment_id.in_(listed_exp_ids),
-            ExperimentalConditions.experiment_type == "HPHT"
-        ).all()
-        
-        # Build preview data
-        to_ongoing = []
-        for exp in to_ongoing_exps:
-            preview_item = {
-                "experiment_id": exp.experiment_id,
-                "current_status": exp.status.value if exp.status else "None",
-                "current_reactor_number": exp.conditions.reactor_number if exp.conditions else None,
-                "new_reactor_number": reactor_number_map.get(exp.experiment_id)
-            }
-            to_ongoing.append(preview_item)
-        
-        to_completed = []
-        for exp in to_completed_exps:
-            preview_item = {
-                "experiment_id": exp.experiment_id,
-                "current_status": exp.status.value,
-                "current_reactor_number": exp.conditions.reactor_number if exp.conditions else None
-            }
-            to_completed.append(preview_item)
-        
-        preview = StatusChangePreview(
-            to_ongoing=to_ongoing,
-            to_completed=to_completed,
-            missing_ids=missing_ids,
-            errors=errors
-        )
-        # Store reactor_number_map for later use in apply
-        preview.reactor_number_map = reactor_number_map  # type: ignore
-        return preview
-    
+            Experiment.id == ExperimentalConditions.experiment_fk,
+        ).filter(Experiment.experiment_id.in_(listed_ids)).all()
+        exp_by_id = {e.experiment_id: e for e in exps}
+        found_ids = set(exp_by_id.keys())
+        missing_ids = [eid for eid in listed_ids if eid not in found_ids]
+
+        changes: List[PlannedChange] = []
+        reactor_targets: Dict[int, str] = {}
+        conflict_errors: List[str] = []
+
+        for r in parsed_rows:
+            exp = exp_by_id.get(r["experiment_id"])
+            if exp is None:
+                continue
+
+            exp_type = exp.conditions.experiment_type if exp.conditions else None
+            changes.append(PlannedChange(
+                experiment_id=exp.experiment_id,
+                experiment_pk=exp.id,
+                current_status=exp.status.value if exp.status else "None",
+                new_status=r["status"],
+                experiment_type=exp_type,
+                reactor_number=exp.conditions.reactor_number if exp.conditions else None,
+                new_reactor_number=r["reactor_number"],
+                new_date=r["date"],
+            ))
+
+            if (
+                r["status"] == ExperimentStatus.ONGOING.value
+                and r["reactor_number"] is not None
+                and _is_eligible_for_occupancy(exp_type)
+            ):
+                existing = reactor_targets.get(r["reactor_number"])
+                if existing is not None:
+                    conflict_errors.append(
+                        f"Reactor {r['reactor_number']} is targeted by multiple rows in "
+                        f"this file: '{existing}' and '{exp.experiment_id}'"
+                    )
+                else:
+                    reactor_targets[r["reactor_number"]] = exp.experiment_id
+
+        if conflict_errors:
+            return StatusChangePreview([], [], missing_ids, conflict_errors, [])
+
+        return StatusChangePreview(changes, [], missing_ids, [], [])
+
     @staticmethod
     def apply_status_changes(
         db: Session,
@@ -158,12 +206,12 @@ class ExperimentStatusService:
         """
         Apply status changes: set listed experiments to ONGOING, others to COMPLETED.
         Optionally update reactor numbers.
-        
+
         Args:
             db: Database session
             experiment_ids_to_ongoing: List of experiment IDs to mark as ONGOING
             reactor_number_map: Optional dict mapping experiment_id to reactor_number
-            
+
         Returns:
             Tuple of (marked_ongoing_count, marked_completed_count, reactor_updates_count, errors)
         """
@@ -172,7 +220,7 @@ class ExperimentStatusService:
         marked_completed = 0
         reactor_updates = 0
         reactor_number_map = reactor_number_map or {}
-        
+
         try:
             # Update experiments to ONGOING and update reactor numbers
             if experiment_ids_to_ongoing:
@@ -182,18 +230,18 @@ class ExperimentStatusService:
                 ).filter(
                     Experiment.experiment_id.in_(experiment_ids_to_ongoing)
                 ).all()
-                
+
                 for exp in to_ongoing_exps:
                     exp.status = ExperimentStatus.ONGOING
                     marked_ongoing += 1
-                    
+
                     # Update reactor_number if provided
                     if exp.experiment_id in reactor_number_map and exp.conditions:
                         new_reactor_number = reactor_number_map[exp.experiment_id]
                         if exp.conditions.reactor_number != new_reactor_number:
                             exp.conditions.reactor_number = new_reactor_number
                             reactor_updates += 1
-            
+
             # Update other ONGOING HPHT experiments to COMPLETED
             to_completed_exps = db.query(Experiment).join(
                 ExperimentalConditions,
@@ -203,16 +251,16 @@ class ExperimentStatusService:
                 ExperimentalConditions.experiment_type == "HPHT",
                 ~Experiment.experiment_id.in_(experiment_ids_to_ongoing) if experiment_ids_to_ongoing else True
             ).all()
-            
+
             for exp in to_completed_exps:
                 exp.status = ExperimentStatus.COMPLETED
                 marked_completed += 1
-            
+
         except Exception as e:
             errors.append(f"Error applying status changes: {e}")
-        
+
         return marked_ongoing, marked_completed, reactor_updates, errors
-    
+
     @staticmethod
     def manage_reactor_occupancy(
         db: Session,
@@ -222,19 +270,19 @@ class ExperimentStatusService:
     ) -> Tuple[int, List[str]]:
         """
         Ensure only one experiment is ONGOING per reactor at a time.
-        
+
         When a new experiment is set to ONGOING with a reactor number, this function
         automatically marks any other ONGOING experiments in the same reactor as COMPLETED.
-        
+
         Args:
             db: Database session
             new_experiment: The experiment being created/updated
             reactor_number: The reactor number being assigned
             commit: Whether to commit changes (default True)
-            
+
         Returns:
             Tuple of (marked_completed_count, warnings)
-            
+
         Example:
             >>> marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
             ...     db, new_exp, reactor_number=3
@@ -243,12 +291,12 @@ class ExperimentStatusService:
         """
         warnings: List[str] = []
         marked_completed = 0
-        
+
         try:
             # Only manage occupancy if the new experiment is ONGOING
             if new_experiment.status != ExperimentStatus.ONGOING:
                 return 0, []
-            
+
             # Find other ONGOING experiments in the same reactor
             conflicting_experiments = db.query(Experiment).join(
                 ExperimentalConditions,
@@ -258,7 +306,7 @@ class ExperimentStatusService:
                 Experiment.status == ExperimentStatus.ONGOING,
                 ExperimentalConditions.reactor_number == reactor_number
             ).all()
-            
+
             # Mark conflicting experiments as COMPLETED
             for exp in conflicting_experiments:
                 exp.status = ExperimentStatus.COMPLETED
@@ -267,14 +315,13 @@ class ExperimentStatusService:
                     f"Reactor {reactor_number}: Marked experiment '{exp.experiment_id}' "
                     f"as COMPLETED (replaced by '{new_experiment.experiment_id}')"
                 )
-            
+
             if commit:
                 db.commit()
-                
+
         except Exception as e:
             warnings.append(f"Error managing reactor occupancy: {e}")
             if commit:
                 db.rollback()
-        
-        return marked_completed, warnings
 
+        return marked_completed, warnings

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -26,6 +26,28 @@ def _is_eligible_for_occupancy(experiment_type: str | None) -> bool:
     return _normalize_type(experiment_type) in _OCCUPANCY_TYPES
 
 
+def _occupant_is_older(occupant_date, incoming_date) -> bool:
+    """True only when both dates are present and the occupant started strictly earlier."""
+    if occupant_date is None or incoming_date is None:
+        return False
+    return occupant_date < incoming_date
+
+
+def _demoted_message(reactor_number: int, demoted_id: str, new_id: str) -> str:
+    return (
+        f"Reactor {reactor_number}: Marked experiment '{demoted_id}' "
+        f"as COMPLETED (replaced by '{new_id}')"
+    )
+
+
+def _not_demoted_message(reactor_number: int, occupant_id: str, new_id: str) -> str:
+    return (
+        f"Reactor {reactor_number}: '{occupant_id}' was NOT completed — its start date "
+        f"is not older than '{new_id}''s (or a start date is missing on one of them). "
+        f"Manual review needed."
+    )
+
+
 @dataclass
 class PlannedChange:
     """One row's planned effect on an Experiment."""
@@ -195,7 +217,42 @@ class ExperimentStatusService:
         if conflict_errors:
             return StatusChangePreview([], [], missing_ids, conflict_errors, [])
 
-        return StatusChangePreview(changes, [], missing_ids, [], [])
+        demotions: List[PlannedDemotion] = []
+        warnings: List[str] = []
+
+        for r in parsed_rows:
+            exp = exp_by_id.get(r["experiment_id"])
+            if exp is None or r["status"] != ExperimentStatus.ONGOING.value or r["reactor_number"] is None:
+                continue
+            exp_type = exp.conditions.experiment_type if exp.conditions else None
+            if not _is_eligible_for_occupancy(exp_type):
+                continue
+
+            occupants = db.query(Experiment).join(
+                ExperimentalConditions,
+                Experiment.id == ExperimentalConditions.experiment_fk,
+            ).filter(
+                Experiment.id != exp.id,
+                Experiment.status == ExperimentStatus.ONGOING,
+                ExperimentalConditions.reactor_number == r["reactor_number"],
+            ).all()
+
+            incoming_date = r["date"].date() if r["date"] is not None else None
+
+            for occ in occupants:
+                occ_date = occ.date.date() if occ.date else None
+                if _occupant_is_older(occ_date, incoming_date):
+                    demotions.append(PlannedDemotion(
+                        experiment_id=occ.experiment_id,
+                        experiment_pk=occ.id,
+                        reactor_number=r["reactor_number"],
+                        triggering_experiment_id=exp.experiment_id,
+                    ))
+                    warnings.append(_demoted_message(r["reactor_number"], occ.experiment_id, exp.experiment_id))
+                else:
+                    warnings.append(_not_demoted_message(r["reactor_number"], occ.experiment_id, exp.experiment_id))
+
+        return StatusChangePreview(changes, demotions, missing_ids, [], warnings)
     
     @staticmethod
     def apply_status_changes(

--- a/backend/services/bulk_uploads/experiment_status.py
+++ b/backend/services/bulk_uploads/experiment_status.py
@@ -386,8 +386,6 @@ class ExperimentStatusService:
 
             if commit:
                 db.commit()
-            else:
-                db.flush()
 
         except Exception as e:
             warnings.append(f"Error managing reactor occupancy: {e}")

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -277,7 +277,7 @@ All endpoints return `UploadResponse`:
 | POST | `/api/bulk-uploads/chemical-inventory` | Create/update `Compound` (reagent) records. |
 | POST | `/api/bulk-uploads/elemental-composition` | Import wide-format elemental composition into `ElementalAnalysis`. Query param: `default_unit` (auto-creates unknown analytes). |
 | POST | `/api/bulk-uploads/actlabs-rock` | Import ActLabs geochemical analysis reports (Excel or CSV). Heuristic header detection. |
-| POST | `/api/bulk-uploads/experiment-status` | Preview + apply bulk ONGOING/COMPLETED transitions. |
+| POST | `/api/bulk-uploads/experiment-status` | Per-row status/date/reactor update. HPHT/Core Flood rows set to ONGOING with a reactor_number auto-complete an older occupant in the same reactor (date-gated); no blanket "complete unlisted HPHT" behavior. |
 | POST | `/api/bulk-uploads/pxrf` | Import pXRF readings from instrument export. |
 | GET | `/api/bulk-uploads/templates/{upload_type}` | Download Excel template. `upload_type`: `scalar-results`, `new-experiments`, `xrd-mineralogy`, `timepoint-modifications`, `rock-inventory`, `chemical-inventory`, `elemental-composition`, `experiment-status`. Returns 404 for types with no template. |
 | GET | `/api/experiments/next-ids` | Returns `{"HPHT": N, "Serum": N, "CF": N}` — next experiment number per type. Used by New Experiments card. |

--- a/docs/project_context/API_REFERENCE.md
+++ b/docs/project_context/API_REFERENCE.md
@@ -277,7 +277,7 @@ All endpoints return `UploadResponse`:
 | POST | `/api/bulk-uploads/chemical-inventory` | Create/update `Compound` (reagent) records. |
 | POST | `/api/bulk-uploads/elemental-composition` | Import wide-format elemental composition into `ElementalAnalysis`. Query param: `default_unit` (auto-creates unknown analytes). |
 | POST | `/api/bulk-uploads/actlabs-rock` | Import ActLabs geochemical analysis reports (Excel or CSV). Heuristic header detection. |
-| POST | `/api/bulk-uploads/experiment-status` | Preview + apply bulk ONGOING/COMPLETED transitions. |
+| POST | `/api/bulk-uploads/experiment-status` | Per-row status/date/reactor update. HPHT/Core Flood rows set to ONGOING with a reactor_number auto-complete an older occupant in the same reactor (date-gated); no blanket "complete unlisted HPHT" behavior. |
 | POST | `/api/bulk-uploads/pxrf` | Import pXRF readings from instrument export. |
 | GET | `/api/bulk-uploads/templates/{upload_type}` | Download Excel template. `upload_type`: `scalar-results`, `new-experiments`, `xrd-mineralogy`, `timepoint-modifications`, `rock-inventory`, `chemical-inventory`, `elemental-composition`, `experiment-status`. Returns 404 for types with no template. |
 | GET | `/api/experiments/next-ids` | Returns `{"HPHT": N, "Serum": N, "CF": N}` — next experiment number per type. Used by New Experiments card. |

--- a/docs/project_context/BULK_UPLOADS.md
+++ b/docs/project_context/BULK_UPLOADS.md
@@ -271,22 +271,34 @@ No template available — upload the ActLabs-exported file directly.
 **Endpoint:** `POST /api/bulk-uploads/experiment-status`
 **Template:** available
 
-Preview and apply bulk experiment status transitions (ONGOING / COMPLETED).
+Set each experiment's status explicitly, per row. Applies to experiments of any
+type — Serum, Autoclave, HPHT, Core Flood.
 
 Logic:
-- All experiments listed in the file are moved to **ONGOING**
-- All ONGOING experiments with HPHT conditions **not** in the file are moved to **COMPLETED**
-- Experiment IDs not found in the database are reported as `missing_ids`
+- Each row sets its own `status` (`ONGOING`, `COMPLETED`, `CANCELLED`, or `QUEUED`; case-insensitive).
+- If `date` is provided, it updates the experiment's start date (`Experiment.date`).
+- If `reactor_number` is provided, it updates `ExperimentalConditions.reactor_number`.
+- Setting an **HPHT or Core Flood** row to `ONGOING` with a `reactor_number` completes
+  an experiment already `ONGOING` in that same reactor, **only if** the occupant's
+  start date is older than the incoming row's start date.
+- If the reactor is held by a newer-or-equal-dated experiment (or either date is
+  missing), nothing is demoted and a warning names both experiments and the reactor.
+- Experiment IDs not found in the database are reported as `missing_ids`.
+- There is no blanket "complete every unlisted ongoing HPHT" behavior — an
+  experiment not referenced in the file is never touched.
+- Invalid `status`/`reactor_number`/`date` values, or two rows targeting the same
+  `reactor_number`, hard-fail the whole upload with no changes applied. A missing
+  `experiment_id` or `status` column does the same.
 
-The endpoint uses a two-phase preview → apply workflow:
-1. Upload the file to see a preview of what will change
-2. The UI displays the pending changes; user confirms
-3. Changes are applied atomically
+The endpoint runs preview validation and apply in one request (no separate
+confirm step): upload the file and the response reports what was applied.
 
 | Column | Required | Notes |
 |--------|----------|-------|
 | experiment_id | ✓ | |
-| reactor_number | | Optional; updates the reactor assignment if provided |
+| status | ✓ | ONGOING, COMPLETED, CANCELLED, or QUEUED (case-insensitive) |
+| reactor_number | | Optional; only meaningful for HPHT / Core Flood experiments |
+| date | | Optional; experiment start date (YYYY-MM-DD or Excel date) |
 
 ---
 

--- a/docs/project_context/experiment_status.md
+++ b/docs/project_context/experiment_status.md
@@ -3,7 +3,7 @@
 **Source:** [backend/services/bulk_uploads/experiment_status.py](../../backend/services/bulk_uploads/experiment_status.py)
 
 ## Overview
-Allows for bulk updating of experiment statuses, specifically marking active experiments as `ONGOING` and automatically handling the transition of unlisted HPHT experiments to `COMPLETED`.
+Allows bulk updating of experiment statuses on a per-row basis: each row sets an explicit `status` (`ONGOING`, `COMPLETED`, `CANCELLED`, or `QUEUED`) for one experiment. Applies to experiments of any type — Serum, Autoclave, HPHT, Core Flood. There is no blanket "complete every unlisted ongoing HPHT" behavior — an experiment not referenced in the file is never touched.
 
 ## Excel Format
 - **Target Sheet:** Reads from a single sheet.
@@ -12,27 +12,33 @@ Allows for bulk updating of experiment statuses, specifically marking active exp
 
 ### Required Columns
 - `experiment_id`
+- `status`: one of `ONGOING`, `COMPLETED`, `CANCELLED`, `QUEUED` (case-insensitive)
 
 ### Optional Columns
-- `reactor_number`
+- `reactor_number`: only meaningful for HPHT / Core Flood experiments
+- `date`: experiment start date (`YYYY-MM-DD` or Excel date). Also used to decide reactor demotion order.
 
 ## Parsing Logic
 - **Headers:** Evaluated case-insensitively.
-- **Experiment IDs:** Compiles a list of unique `experiment_id`s that should be marked as `ONGOING`.
-- **Reactor Numbers:** Parses the optional `reactor_number` per row, storing it in a mapping dictionary for later application to the experiment's conditions.
+- **Rows:** Each row is parsed independently into a planned change (`experiment_id`, `status`, optional `reactor_number`, optional `date`). Invalid `status`/`reactor_number`/`date` values produce a row-level error.
+- **Missing required columns:** A missing `experiment_id` or `status` column hard-fails the whole upload with no changes applied.
+- **Same-reactor conflict:** If two rows both set an HPHT/Core-Flood-eligible experiment to `ONGOING` in the same `reactor_number`, the file is rejected as internally inconsistent.
 
 ## Behavior and Flow
 
 ### Preview Phase (`preview_status_changes_from_excel`)
 Generates a `StatusChangePreview` object that includes:
-- Experiments to be set to `ONGOING` (from the uploaded file).
-- Experiments to be set to `COMPLETED` (currently `ONGOING` HPHT experiments that are *not* present in the uploaded file).
-- Missing IDs and validation errors.
+- `changes`: planned per-row status/date/reactor changes (`PlannedChange` list).
+- `demotions`: planned reactor demotions (`PlannedDemotion` list) — for HPHT/Core-Flood-eligible rows set to `ONGOING` with a `reactor_number`, where an older same-reactor occupant exists.
+- `missing_ids`: experiment IDs from the file not found in the database.
+- `errors`: column/row-level validation errors and same-reactor conflicts (any non-empty `errors` blocks the whole upload).
+- `warnings`: explanatory notes, including cases where a same-reactor occupant is *not* demoted (newer-or-equal start date, or a missing start date on either side).
 
 ### Application Phase (`apply_status_changes`)
-- Sets the listed experiments to `ONGOING`.
-- Sets the unlisted `ONGOING` experiments to `COMPLETED`.
-- Updates the `reactor_number` in `ExperimentalConditions` when a value is provided in the upload.
+- Sets each row's `status` on its experiment.
+- Writes `date` to the experiment's start date when provided.
+- Updates `reactor_number` in `ExperimentalConditions` when provided and different from the current value.
+- For eligible ONGOING rows with a `reactor_number`, executes the planned demotion via `manage_reactor_occupancy` (only demotes an occupant whose start date is strictly older; otherwise leaves it `ONGOING` with a warning).
 
 ## Output
-The apply step returns a tuple: `(marked_ongoing, marked_completed, reactor_updates, errors)`.
+The apply step returns an `ApplyResult` with fields: `status_changes_applied`, `demotions_applied`, `reactor_updates`, `date_updates`, `warnings`, `errors`.

--- a/docs/superpowers/plans/2026-07-22-issue-66-experiment-status-per-row.md
+++ b/docs/superpowers/plans/2026-07-22-issue-66-experiment-status-per-row.md
@@ -1,0 +1,1763 @@
+# Issue #66 — Experiment Status Bulk Upload: Per-Row Status, Start Date, Reactor-Scoped Date-Aware Demotion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the Experiment Status Update bulk upload from a whole-world "snapshot" model (forces every listed experiment to ONGOING, blanket-completes every unlisted ongoing HPHT experiment) into an explicit per-row model: each row carries its own `status`, and reactor demotion is scoped to the physical reactor and gated on start date, for HPHT and Core Flood experiments.
+
+**Architecture:** `ExperimentStatusService` (`backend/services/bulk_uploads/experiment_status.py`) gets a rewritten `preview_status_changes_from_excel` (per-row parse/validate → `StatusChangePreview` with planned changes + planned demotions) and `apply_status_changes` (consumes a `StatusChangePreview`, writes status/date/reactor_number, then reuses `manage_reactor_occupancy` — now with an optional start-date guard — to execute demotions). The FastAPI router wraps these two calls unchanged in shape (preview → apply → commit/rollback), the Excel template gets four columns + an INSTRUCTIONS sheet, and the frontend tile copy is updated. No database migration — every field involved already exists.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.x ORM, pandas (Excel parsing), openpyxl (Excel template generation), pytest (backend tests).
+
+## Global Constraints
+
+- No database migration — `Experiment.status`, `Experiment.date`, `ExperimentalConditions.experiment_type`, `ExperimentalConditions.reactor_number` already exist.
+- `backend/services/bulk_uploads/` is a locked component (`docs/LOCKED_COMPONENTS.md`) — this issue is the explicit user instruction authorizing modification of `experiment_status.py` only. Do not touch other files in that directory.
+- `manage_reactor_occupancy`'s existing callers (`backend/services/bulk_uploads/new_experiments.py` lines ~599, ~671, and the legacy Streamlit create path) must behave **exactly as before** — they never pass the new guard parameter.
+- Keep the existing all-or-nothing transaction behavior: commit only if there are no hard errors, otherwise roll back.
+- Confirmed decisions on the issue's four open items (user sign-off obtained 2026-07-22):
+  1. **Missing start dates:** if either the incoming row's date or the occupant's date is missing, do not demote — warn instead.
+  2. **`status` column:** required. A missing `status` (or `experiment_id`) column hard-errors the whole upload with no changes applied.
+  3. **Multiple rows targeting the same reactor:** detected in preview and rejected as a hard error (whole upload fails, nothing applied).
+  4. **Same-day start dates:** "newer-or-equal → warn" — a same-day swap warns rather than auto-demoting.
+- Status values are case-insensitive on input, normalized to the `ExperimentStatus` enum's upper-case values (`ONGOING`, `COMPLETED`, `CANCELLED`, `QUEUED`).
+- `experiment_type` is a free string column — normalize case/whitespace defensively when comparing against `"HPHT"` / `"Core Flood"` rather than assuming exact casing.
+- The reactor occupancy/demotion gate is about the **physical reactor**: an occupant of *any* experiment type in that reactor is a demotion candidate. The HPHT/Core-Flood restriction applies only to which **incoming** rows trigger a check.
+- `UploadResponse` (`backend/api/schemas/bulk_upload.py`) already has a `warnings: list[str] = []` field — no schema change needed there.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `backend/services/bulk_uploads/experiment_status.py` | Rewrite `StatusChangePreview` (+ new `PlannedChange`, `PlannedDemotion`, `ApplyResult` dataclasses), rewrite `preview_status_changes_from_excel`, rewrite `apply_status_changes`, add a start-date guard to `manage_reactor_occupancy`. |
+| `backend/api/routers/bulk_uploads.py` | Rewrite `upload_experiment_status` (~line 580) to the new preview/apply shapes; rewrite the `"experiment-status"` branch of `_get_template_bytes` (~line 988) to 4 columns + INSTRUCTIONS sheet. |
+| `frontend/src/pages/BulkUploads.tsx` | Update the Experiment Status Update tile's `description` and `helpText` (~line 335). |
+| `tests/services/bulk_uploads/test_experiment_status.py` | Full rewrite to match the new per-row contract. |
+| `tests/api/test_bulk_uploads.py` | Update the `experiment-status` router-level mock test (~line 315) to the new preview/apply shapes; add a template-content test. |
+| `docs/api/API_REFERENCE.md` | Update the `experiment-status` endpoint/template row descriptions. |
+| `docs/user_guide/BULK_UPLOADS.md` | Rewrite section "11 — Experiment Status Update". |
+
+---
+
+### Task 1: Preview — parsing, validation, missing IDs, same-reactor-in-file conflict
+
+**Files:**
+- Modify: `backend/services/bulk_uploads/experiment_status.py` (full rewrite via Write — old `apply_status_changes` and `manage_reactor_occupancy` are carried over unchanged for now; Tasks 3–4 rewrite them)
+- Test: `tests/services/bulk_uploads/test_experiment_status.py` (rewrite preview-section tests)
+
+**Interfaces:**
+- Produces: `PlannedChange` dataclass (`experiment_id: str`, `experiment_pk: int`, `current_status: str`, `new_status: str`, `experiment_type: str | None`, `reactor_number: int | None`, `new_reactor_number: int | None`, `new_date: pd.Timestamp | None`), `PlannedDemotion` dataclass (`experiment_id: str`, `experiment_pk: int`, `reactor_number: int`, `triggering_experiment_id: str`), `StatusChangePreview` dataclass (`changes: List[PlannedChange]`, `demotions: List[PlannedDemotion]`, `missing_ids: List[str]`, `errors: List[str]`, `warnings: List[str]`), module-level `_normalize_type(experiment_type: str | None) -> str` and `_is_eligible_for_occupancy(experiment_type: str | None) -> bool`, and `ExperimentStatusService.preview_status_changes_from_excel(db, file_bytes) -> StatusChangePreview` (demotions/warnings always `[]` until Task 2).
+- Consumes: nothing new (uses existing `Experiment`, `ExperimentalConditions`, `ExperimentStatus`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire contents of `tests/services/bulk_uploads/test_experiment_status.py` with:
+
+```python
+"""Tests for ExperimentStatusService.
+
+Per-row model:
+- Each row sets its own `status` (ONGOING / COMPLETED / CANCELLED / QUEUED).
+- `reactor_number` and `date` are optional; `date` is the experiment start date.
+- Setting an HPHT or Core Flood row to ONGOING with a reactor_number schedules
+  demotion of an older ONGOING occupant in the same reactor (see Task 2 tests).
+- A missing `experiment_id` or `status` column hard-errors the whole upload.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.orm import Session
+
+from database import Experiment
+from database.models import ExperimentalConditions
+from database.models.enums import ExperimentStatus
+from backend.services.bulk_uploads.experiment_status import ExperimentStatusService
+
+from .excel_helpers import make_excel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _seed_experiment(
+    db: Session,
+    experiment_id: str,
+    exp_num: int,
+    status: ExperimentStatus = ExperimentStatus.ONGOING,
+    experiment_type: str | None = None,
+    reactor_number: int | None = None,
+    date=None,
+) -> Experiment:
+    exp = Experiment(
+        experiment_id=experiment_id,
+        experiment_number=exp_num,
+        status=status,
+        date=date,
+    )
+    db.add(exp)
+    db.flush()
+
+    if experiment_type is not None or reactor_number is not None:
+        cond = ExperimentalConditions(
+            experiment_fk=exp.id,
+            experiment_id=experiment_id,
+            experiment_type=experiment_type,
+            reactor_number=reactor_number,
+        )
+        db.add(cond)
+        db.flush()
+
+    return exp
+
+
+# ---------------------------------------------------------------------------
+# Column / row validation
+# ---------------------------------------------------------------------------
+
+def test_preview_missing_experiment_id_column_returns_error(db_session: Session):
+    xlsx = make_excel(["status", "reactor_number"], [["ONGOING", 3]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "experiment_id" in preview.errors[0]
+    assert preview.changes == []
+
+
+def test_preview_missing_status_column_returns_error(db_session: Session):
+    xlsx = make_excel(["experiment_id", "reactor_number"], [["HPHT_ST001", 3]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "status" in preview.errors[0]
+    assert preview.changes == []
+
+
+def test_preview_builds_planned_change_per_row(db_session: Session):
+    """A valid row produces one PlannedChange with the parsed status/reactor/date."""
+    _seed_experiment(db_session, "HPHT_ST001", 6601, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST001", "ongoing", 3, "2026-07-15"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert len(preview.changes) == 1
+    change = preview.changes[0]
+    assert change.experiment_id == "HPHT_ST001"
+    assert change.new_status == "ONGOING"
+    assert change.new_reactor_number == 3
+    assert change.new_date is not None
+    assert change.new_date.date().isoformat() == "2026-07-15"
+
+
+def test_preview_records_missing_experiment_ids(db_session: Session):
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["NONEXISTENT_ST", "ONGOING", 2]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert "NONEXISTENT_ST" in preview.missing_ids
+    assert preview.changes == []
+    assert preview.errors == []
+
+
+def test_preview_invalid_status_produces_row_error(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST002", 6602, ExperimentStatus.ONGOING, "HPHT")
+    xlsx = make_excel(
+        ["experiment_id", "status"],
+        [["HPHT_ST002", "IN_PROGRESS"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "Invalid status" in preview.errors[0]
+
+
+def test_preview_invalid_reactor_number_produces_row_error(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST003", 6603, ExperimentStatus.ONGOING, "HPHT")
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST003", "ONGOING", "not-a-number"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "Invalid reactor_number" in preview.errors[0]
+
+
+def test_preview_invalid_date_produces_row_error(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST004", 6604, ExperimentStatus.ONGOING, "HPHT")
+    xlsx = make_excel(
+        ["experiment_id", "status", "date"],
+        [["HPHT_ST004", "ONGOING", "not-a-date"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "Invalid date" in preview.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Same-reactor-in-file conflict (Open Item #3: error, don't let apply order decide)
+# ---------------------------------------------------------------------------
+
+def test_preview_same_reactor_multiple_rows_errors(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST005", 6605, ExperimentStatus.COMPLETED, "HPHT")
+    _seed_experiment(db_session, "HPHT_ST006", 6606, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST005", "ONGOING", 4], ["HPHT_ST006", "ONGOING", 4]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert len(preview.errors) == 1
+    assert "Reactor 4" in preview.errors[0]
+    assert "HPHT_ST005" in preview.errors[0]
+    assert "HPHT_ST006" in preview.errors[0]
+    assert preview.changes == []
+
+
+def test_preview_serum_rows_same_reactor_do_not_conflict(db_session: Session):
+    """The same-reactor conflict check only applies to HPHT/Core Flood rows."""
+    _seed_experiment(db_session, "Serum_ST001", 6607, ExperimentStatus.COMPLETED, "Serum")
+    _seed_experiment(db_session, "Serum_ST002", 6608, ExperimentStatus.COMPLETED, "Serum")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["Serum_ST001", "ONGOING", 4], ["Serum_ST002", "ONGOING", 4]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert len(preview.changes) == 2
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v`
+Expected: FAIL — `AttributeError: 'StatusChangePreview' object has no attribute 'changes'` (or similar), since the current dataclass only has `to_ongoing`/`to_completed`.
+
+- [ ] **Step 3: Rewrite `backend/services/bulk_uploads/experiment_status.py`**
+
+Write the full file (this keeps the current `apply_status_changes` and `manage_reactor_occupancy` methods byte-for-byte identical to today — Tasks 3–4 rewrite them):
+
+```python
+from __future__ import annotations
+
+import io
+from typing import List, Tuple, Dict, Any
+from dataclasses import dataclass
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from database import Experiment
+from database.models import ExperimentalConditions
+from database.models.enums import ExperimentStatus
+
+
+_VALID_STATUSES = {s.value for s in ExperimentStatus}
+_OCCUPANCY_TYPES = {"hpht", "core flood"}
+
+
+def _normalize_type(experiment_type: str | None) -> str:
+    """Lowercase + collapse whitespace so 'HPHT ', 'Core  Flood', etc. compare cleanly."""
+    return " ".join((experiment_type or "").strip().lower().split())
+
+
+def _is_eligible_for_occupancy(experiment_type: str | None) -> bool:
+    """True for HPHT / Core Flood — the types with physical reactor occupancy."""
+    return _normalize_type(experiment_type) in _OCCUPANCY_TYPES
+
+
+@dataclass
+class PlannedChange:
+    """One row's planned effect on an Experiment."""
+    experiment_id: str
+    experiment_pk: int
+    current_status: str
+    new_status: str
+    experiment_type: str | None
+    reactor_number: int | None       # current ExperimentalConditions.reactor_number
+    new_reactor_number: int | None   # value from the row, if provided
+    new_date: pd.Timestamp | None    # value from the row, if provided
+
+
+@dataclass
+class PlannedDemotion:
+    """One reactor occupant that will be completed when its row's demotion is applied."""
+    experiment_id: str
+    experiment_pk: int
+    reactor_number: int
+    triggering_experiment_id: str
+
+
+@dataclass
+class StatusChangePreview:
+    """Preview of per-row status changes and reactor demotions to be applied."""
+    changes: List[PlannedChange]
+    demotions: List[PlannedDemotion]
+    missing_ids: List[str]
+    errors: List[str]
+    warnings: List[str]
+
+
+class ExperimentStatusService:
+    """Service for bulk updating experiment statuses"""
+
+    @staticmethod
+    def preview_status_changes_from_excel(
+        db: Session,
+        file_bytes: bytes,
+    ) -> StatusChangePreview:
+        """
+        Preview per-row status/date/reactor changes from an Excel file.
+
+        Args:
+            db: Database session
+            file_bytes: Excel file bytes with 'experiment_id' (required), 'status'
+                       (required), 'reactor_number' (optional), 'date' (optional) columns
+
+        Returns:
+            StatusChangePreview with planned per-row changes, planned reactor
+            demotions, missing experiment IDs, row/column-level errors, and warnings.
+        """
+        try:
+            df = pd.read_excel(io.BytesIO(file_bytes))
+        except Exception as e:
+            return StatusChangePreview([], [], [], [f"Failed to read Excel: {e}"], [])
+
+        col_map = {str(c).lower().strip(): str(c) for c in df.columns}
+
+        if "experiment_id" not in col_map:
+            return StatusChangePreview([], [], [], ["Missing required column: 'experiment_id'"], [])
+        if "status" not in col_map:
+            return StatusChangePreview([], [], [], ["Missing required column: 'status'"], [])
+
+        rename_map = {col_map["experiment_id"]: "experiment_id", col_map["status"]: "status"}
+        if "reactor_number" in col_map:
+            rename_map[col_map["reactor_number"]] = "reactor_number"
+        if "date" in col_map:
+            rename_map[col_map["date"]] = "date"
+        df = df.rename(columns=rename_map)
+
+        errors: List[str] = []
+        parsed_rows: List[Dict[str, Any]] = []
+        seen_ids: set = set()
+
+        for _, row in df.iterrows():
+            exp_id = str(row.get("experiment_id") or "").strip()
+            if not exp_id or exp_id in seen_ids:
+                continue
+            seen_ids.add(exp_id)
+
+            row_errors: List[str] = []
+
+            raw_status = row.get("status")
+            status_str = str(raw_status).strip().upper() if pd.notna(raw_status) else ""
+            if status_str not in _VALID_STATUSES:
+                row_errors.append(f"Invalid status for {exp_id}: {raw_status!r}")
+
+            reactor_number = None
+            if "reactor_number" in df.columns:
+                reactor_val = row.get("reactor_number")
+                if pd.notna(reactor_val):
+                    try:
+                        reactor_number = int(reactor_val)
+                    except (ValueError, TypeError):
+                        row_errors.append(f"Invalid reactor_number for {exp_id}: {reactor_val}")
+
+            new_date = None
+            if "date" in df.columns:
+                date_val = row.get("date")
+                if pd.notna(date_val):
+                    try:
+                        new_date = pd.Timestamp(date_val)
+                    except (ValueError, TypeError):
+                        row_errors.append(f"Invalid date for {exp_id}: {date_val}")
+
+            if row_errors:
+                errors.extend(row_errors)
+                continue
+
+            parsed_rows.append({
+                "experiment_id": exp_id,
+                "status": status_str,
+                "reactor_number": reactor_number,
+                "date": new_date,
+            })
+
+        if not parsed_rows and not errors:
+            return StatusChangePreview([], [], [], ["No valid experiment IDs found in file"], [])
+        if errors:
+            return StatusChangePreview([], [], [], errors, [])
+
+        listed_ids = [r["experiment_id"] for r in parsed_rows]
+        exps = db.query(Experiment).outerjoin(
+            ExperimentalConditions,
+            Experiment.id == ExperimentalConditions.experiment_fk,
+        ).filter(Experiment.experiment_id.in_(listed_ids)).all()
+        exp_by_id = {e.experiment_id: e for e in exps}
+        found_ids = set(exp_by_id.keys())
+        missing_ids = [eid for eid in listed_ids if eid not in found_ids]
+
+        changes: List[PlannedChange] = []
+        reactor_targets: Dict[int, str] = {}
+        conflict_errors: List[str] = []
+
+        for r in parsed_rows:
+            exp = exp_by_id.get(r["experiment_id"])
+            if exp is None:
+                continue
+
+            exp_type = exp.conditions.experiment_type if exp.conditions else None
+            changes.append(PlannedChange(
+                experiment_id=exp.experiment_id,
+                experiment_pk=exp.id,
+                current_status=exp.status.value if exp.status else "None",
+                new_status=r["status"],
+                experiment_type=exp_type,
+                reactor_number=exp.conditions.reactor_number if exp.conditions else None,
+                new_reactor_number=r["reactor_number"],
+                new_date=r["date"],
+            ))
+
+            if (
+                r["status"] == ExperimentStatus.ONGOING.value
+                and r["reactor_number"] is not None
+                and _is_eligible_for_occupancy(exp_type)
+            ):
+                existing = reactor_targets.get(r["reactor_number"])
+                if existing is not None:
+                    conflict_errors.append(
+                        f"Reactor {r['reactor_number']} is targeted by multiple rows in "
+                        f"this file: '{existing}' and '{exp.experiment_id}'"
+                    )
+                else:
+                    reactor_targets[r["reactor_number"]] = exp.experiment_id
+
+        if conflict_errors:
+            return StatusChangePreview([], [], missing_ids, conflict_errors, [])
+
+        return StatusChangePreview(changes, [], missing_ids, [], [])
+
+    @staticmethod
+    def apply_status_changes(
+        db: Session,
+        experiment_ids_to_ongoing: List[str],
+        reactor_number_map: Dict[str, int] = None
+    ) -> Tuple[int, int, int, List[str]]:
+        """
+        Apply status changes: set listed experiments to ONGOING, others to COMPLETED.
+        Optionally update reactor numbers.
+
+        Args:
+            db: Database session
+            experiment_ids_to_ongoing: List of experiment IDs to mark as ONGOING
+            reactor_number_map: Optional dict mapping experiment_id to reactor_number
+
+        Returns:
+            Tuple of (marked_ongoing_count, marked_completed_count, reactor_updates_count, errors)
+        """
+        errors: List[str] = []
+        marked_ongoing = 0
+        marked_completed = 0
+        reactor_updates = 0
+        reactor_number_map = reactor_number_map or {}
+
+        try:
+            # Update experiments to ONGOING and update reactor numbers
+            if experiment_ids_to_ongoing:
+                to_ongoing_exps = db.query(Experiment).outerjoin(
+                    ExperimentalConditions,
+                    Experiment.id == ExperimentalConditions.experiment_fk
+                ).filter(
+                    Experiment.experiment_id.in_(experiment_ids_to_ongoing)
+                ).all()
+
+                for exp in to_ongoing_exps:
+                    exp.status = ExperimentStatus.ONGOING
+                    marked_ongoing += 1
+
+                    # Update reactor_number if provided
+                    if exp.experiment_id in reactor_number_map and exp.conditions:
+                        new_reactor_number = reactor_number_map[exp.experiment_id]
+                        if exp.conditions.reactor_number != new_reactor_number:
+                            exp.conditions.reactor_number = new_reactor_number
+                            reactor_updates += 1
+
+            # Update other ONGOING HPHT experiments to COMPLETED
+            to_completed_exps = db.query(Experiment).join(
+                ExperimentalConditions,
+                Experiment.id == ExperimentalConditions.experiment_fk
+            ).filter(
+                Experiment.status == ExperimentStatus.ONGOING,
+                ExperimentalConditions.experiment_type == "HPHT",
+                ~Experiment.experiment_id.in_(experiment_ids_to_ongoing) if experiment_ids_to_ongoing else True
+            ).all()
+
+            for exp in to_completed_exps:
+                exp.status = ExperimentStatus.COMPLETED
+                marked_completed += 1
+
+        except Exception as e:
+            errors.append(f"Error applying status changes: {e}")
+
+        return marked_ongoing, marked_completed, reactor_updates, errors
+
+    @staticmethod
+    def manage_reactor_occupancy(
+        db: Session,
+        new_experiment: Experiment,
+        reactor_number: int,
+        commit: bool = True
+    ) -> Tuple[int, List[str]]:
+        """
+        Ensure only one experiment is ONGOING per reactor at a time.
+
+        When a new experiment is set to ONGOING with a reactor number, this function
+        automatically marks any other ONGOING experiments in the same reactor as COMPLETED.
+
+        Args:
+            db: Database session
+            new_experiment: The experiment being created/updated
+            reactor_number: The reactor number being assigned
+            commit: Whether to commit changes (default True)
+
+        Returns:
+            Tuple of (marked_completed_count, warnings)
+
+        Example:
+            >>> marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+            ...     db, new_exp, reactor_number=3
+            ... )
+            >>> print(f"Marked {marked} experiments as completed")
+        """
+        warnings: List[str] = []
+        marked_completed = 0
+
+        try:
+            # Only manage occupancy if the new experiment is ONGOING
+            if new_experiment.status != ExperimentStatus.ONGOING:
+                return 0, []
+
+            # Find other ONGOING experiments in the same reactor
+            conflicting_experiments = db.query(Experiment).join(
+                ExperimentalConditions,
+                Experiment.id == ExperimentalConditions.experiment_fk
+            ).filter(
+                Experiment.id != new_experiment.id,  # Exclude the current experiment
+                Experiment.status == ExperimentStatus.ONGOING,
+                ExperimentalConditions.reactor_number == reactor_number
+            ).all()
+
+            # Mark conflicting experiments as COMPLETED
+            for exp in conflicting_experiments:
+                exp.status = ExperimentStatus.COMPLETED
+                marked_completed += 1
+                warnings.append(
+                    f"Reactor {reactor_number}: Marked experiment '{exp.experiment_id}' "
+                    f"as COMPLETED (replaced by '{new_experiment.experiment_id}')"
+                )
+
+            if commit:
+                db.commit()
+
+        except Exception as e:
+            warnings.append(f"Error managing reactor occupancy: {e}")
+            if commit:
+                db.rollback()
+
+        return marked_completed, warnings
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v`
+Expected: All tests in the file PASS (the preview-section tests written in Step 1; `apply_status_changes` still uses the old signature so no other test file references it yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/bulk_uploads/experiment_status.py tests/services/bulk_uploads/test_experiment_status.py
+git commit -m "$(cat <<'EOF'
+[#66] Rework status preview to per-row model
+
+- Tests added: yes
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 2: Preview — reactor demotion planning (read-only)
+
+**Files:**
+- Modify: `backend/services/bulk_uploads/experiment_status.py` (extend `preview_status_changes_from_excel`, add 3 module-level helpers)
+- Test: `tests/services/bulk_uploads/test_experiment_status.py` (append demotion-planning tests)
+
+**Interfaces:**
+- Consumes: `PlannedChange`, `PlannedDemotion`, `StatusChangePreview`, `_is_eligible_for_occupancy` from Task 1.
+- Produces: module-level `_occupant_is_older(occupant_date: date | None, incoming_date: date | None) -> bool`, `_demoted_message(reactor_number: int, demoted_id: str, new_id: str) -> str`, `_not_demoted_message(reactor_number: int, occupant_id: str, new_id: str) -> str`. `preview_status_changes_from_excel` now populates `demotions` and `warnings` on the returned `StatusChangePreview` (previously always `[]`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/services/bulk_uploads/test_experiment_status.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Reactor demotion planning (read-only — preview does not mutate the DB)
+# ---------------------------------------------------------------------------
+
+def test_preview_demotes_older_hpht_occupant_in_same_reactor(db_session: Session):
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST010", 6610, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=5, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST011", 6611, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST011", "ONGOING", 5, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert len(preview.demotions) == 1
+    assert preview.demotions[0].experiment_id == "HPHT_ST010"
+    assert preview.demotions[0].triggering_experiment_id == "HPHT_ST011"
+    assert any("HPHT_ST010" in w and "COMPLETED" in w for w in preview.warnings)
+
+
+def test_preview_demotes_older_core_flood_occupant_in_same_reactor(db_session: Session):
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "CF_ST001", 6612, ExperimentStatus.ONGOING, "Core Flood",
+        reactor_number=1, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "CF_ST002", 6613, ExperimentStatus.COMPLETED, "Core Flood")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["CF_ST002", "ONGOING", 1, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    demoted_ids = [d.experiment_id for d in preview.demotions]
+    assert "CF_ST001" in demoted_ids
+
+
+def test_preview_warns_no_demote_when_occupant_newer(db_session: Session):
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST012", 6614, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=6, date=datetime(2026, 6, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST013", 6615, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST013", "ONGOING", 6, "2026-01-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert preview.demotions == []
+    assert any("HPHT_ST012" in w for w in preview.warnings)
+
+
+def test_preview_warns_no_demote_when_occupant_equal_date(db_session: Session):
+    """Open Item #4: same-day → warn, do not demote."""
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST014", 6616, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=7, date=datetime(2026, 6, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST015", 6617, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST015", "ONGOING", 7, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert any("HPHT_ST014" in w for w in preview.warnings)
+
+
+def test_preview_warns_no_demote_when_incoming_date_missing(db_session: Session):
+    """Open Item #1: missing incoming date → don't demote, warn."""
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST016", 6618, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=8, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST017", 6619, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST017", "ONGOING", 8]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert any("HPHT_ST016" in w for w in preview.warnings)
+
+
+def test_preview_warns_no_demote_when_occupant_date_missing(db_session: Session):
+    """Open Item #1: missing occupant date → don't demote, warn."""
+    _seed_experiment(
+        db_session, "HPHT_ST018", 6620, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=9, date=None,
+    )
+    _seed_experiment(db_session, "HPHT_ST019", 6621, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST019", "ONGOING", 9, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert any("HPHT_ST018" in w for w in preview.warnings)
+
+
+def test_preview_serum_ongoing_with_reactor_no_demotion(db_session: Session):
+    """Non-occupancy types never trigger demotion, even if ONGOING with a reactor_number."""
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "Serum_ST003", 6622, ExperimentStatus.ONGOING, "Serum",
+        reactor_number=10, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "Serum_ST004", 6623, ExperimentStatus.COMPLETED, "Serum")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["Serum_ST004", "ONGOING", 10, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert preview.warnings == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v -k demote or -k occupant or -k missing_date`
+Expected: FAIL — `preview.demotions` is always `[]` and `preview.warnings` is always `[]` (demotion planning not implemented yet).
+
+- [ ] **Step 3: Add the demotion-planning helpers and extend `preview_status_changes_from_excel`**
+
+Add these three module-level functions to `backend/services/bulk_uploads/experiment_status.py`, directly below `_is_eligible_for_occupancy`:
+
+```python
+def _occupant_is_older(occupant_date, incoming_date) -> bool:
+    """True only when both dates are present and the occupant started strictly earlier."""
+    if occupant_date is None or incoming_date is None:
+        return False
+    return occupant_date < incoming_date
+
+
+def _demoted_message(reactor_number: int, demoted_id: str, new_id: str) -> str:
+    return (
+        f"Reactor {reactor_number}: Marked experiment '{demoted_id}' "
+        f"as COMPLETED (replaced by '{new_id}')"
+    )
+
+
+def _not_demoted_message(reactor_number: int, occupant_id: str, new_id: str) -> str:
+    return (
+        f"Reactor {reactor_number}: '{occupant_id}' was NOT completed — its start date "
+        f"is not older than '{new_id}''s (or a start date is missing on one of them). "
+        f"Manual review needed."
+    )
+```
+
+In `preview_status_changes_from_excel`, replace the final line:
+
+```python
+        return StatusChangePreview(changes, [], missing_ids, [], [])
+```
+
+with:
+
+```python
+        demotions: List[PlannedDemotion] = []
+        warnings: List[str] = []
+
+        for r in parsed_rows:
+            exp = exp_by_id.get(r["experiment_id"])
+            if exp is None or r["status"] != ExperimentStatus.ONGOING.value or r["reactor_number"] is None:
+                continue
+            exp_type = exp.conditions.experiment_type if exp.conditions else None
+            if not _is_eligible_for_occupancy(exp_type):
+                continue
+
+            occupants = db.query(Experiment).join(
+                ExperimentalConditions,
+                Experiment.id == ExperimentalConditions.experiment_fk,
+            ).filter(
+                Experiment.id != exp.id,
+                Experiment.status == ExperimentStatus.ONGOING,
+                ExperimentalConditions.reactor_number == r["reactor_number"],
+            ).all()
+
+            incoming_date = r["date"].date() if r["date"] is not None else None
+
+            for occ in occupants:
+                occ_date = occ.date.date() if occ.date else None
+                if _occupant_is_older(occ_date, incoming_date):
+                    demotions.append(PlannedDemotion(
+                        experiment_id=occ.experiment_id,
+                        experiment_pk=occ.id,
+                        reactor_number=r["reactor_number"],
+                        triggering_experiment_id=exp.experiment_id,
+                    ))
+                    warnings.append(_demoted_message(r["reactor_number"], occ.experiment_id, exp.experiment_id))
+                else:
+                    warnings.append(_not_demoted_message(r["reactor_number"], occ.experiment_id, exp.experiment_id))
+
+        return StatusChangePreview(changes, demotions, missing_ids, [], warnings)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/bulk_uploads/experiment_status.py tests/services/bulk_uploads/test_experiment_status.py
+git commit -m "$(cat <<'EOF'
+[#66] Plan reactor demotions in status preview
+
+- Tests added: yes
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 3: `manage_reactor_occupancy` — optional start-date guard
+
+**Files:**
+- Modify: `backend/services/bulk_uploads/experiment_status.py` (add `_UNSET` sentinel, extend `manage_reactor_occupancy`)
+- Test: `tests/services/bulk_uploads/test_experiment_status.py` (append `manage_reactor_occupancy`-focused tests)
+
+**Interfaces:**
+- Consumes: `_demoted_message`, `_not_demoted_message` from Task 2.
+- Produces: `ExperimentStatusService.manage_reactor_occupancy(db, new_experiment, reactor_number, commit=True, newer_than=_UNSET) -> Tuple[int, List[str]]`. Callers that omit `newer_than` get byte-identical behavior to today (unconditional demotion of every ONGOING occupant in the reactor). Callers that pass `newer_than` (a `datetime` or `None`) activate the date guard: an occupant is demoted only if its `date` is strictly older (by calendar date) than `newer_than`; a missing occupant date, a missing `newer_than`, or a newer-or-equal occupant date produces a warning instead.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/services/bulk_uploads/test_experiment_status.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# manage_reactor_occupancy — start-date guard
+# ---------------------------------------------------------------------------
+
+def test_manage_reactor_occupancy_legacy_call_still_demotes_unconditionally(db_session: Session):
+    """Regression: callers that don't pass newer_than (new_experiments.py, legacy create)
+    keep demoting regardless of start dates."""
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST020", 6624, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=11, date=datetime(2026, 12, 31),  # newer than the incoming experiment
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST021", 6625, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=11, date=datetime(2026, 1, 1),
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 11, commit=False,
+    )
+
+    assert marked == 1
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.COMPLETED
+    assert any("COMPLETED" in w for w in warnings)
+
+
+def test_manage_reactor_occupancy_guard_demotes_older_occupant(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST022", 6626, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=12, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST023", 6627, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=12, date=datetime(2026, 6, 1),
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 12, commit=False, newer_than=datetime(2026, 6, 1),
+    )
+
+    assert marked == 1
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.COMPLETED
+
+
+def test_manage_reactor_occupancy_guard_warns_on_newer_or_equal_occupant(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST024", 6628, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=13, date=datetime(2026, 6, 1),
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST025", 6629, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=13, date=datetime(2026, 1, 1),
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 13, commit=False, newer_than=datetime(2026, 1, 1),
+    )
+
+    assert marked == 0
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.ONGOING
+    assert any("HPHT_ST024" in w and "HPHT_ST025" in w for w in warnings)
+
+
+def test_manage_reactor_occupancy_guard_warns_when_newer_than_is_none(db_session: Session):
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST026", 6630, ExperimentStatus.ONGOING, "HPHT", reactor_number=14,
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST027", 6631, ExperimentStatus.ONGOING, "HPHT", reactor_number=14,
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 14, commit=False, newer_than=None,
+    )
+
+    assert marked == 0
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.ONGOING
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v -k manage_reactor_occupancy`
+Expected: FAIL — `TypeError: manage_reactor_occupancy() got an unexpected keyword argument 'newer_than'`.
+
+- [ ] **Step 3: Add the guard**
+
+Add the `_UNSET` sentinel directly below the `_OCCUPANCY_TYPES` constant:
+
+```python
+_UNSET = object()
+```
+
+Add `from datetime import datetime` to the top-of-file imports (alongside the existing `import io` line).
+
+Replace the `manage_reactor_occupancy` method with:
+
+```python
+    @staticmethod
+    def manage_reactor_occupancy(
+        db: Session,
+        new_experiment: Experiment,
+        reactor_number: int,
+        commit: bool = True,
+        newer_than: datetime | None = _UNSET,
+    ) -> Tuple[int, List[str]]:
+        """
+        Ensure only one experiment is ONGOING per reactor at a time.
+
+        When a new experiment is set to ONGOING with a reactor number, this function
+        marks other ONGOING experiments in the same reactor as COMPLETED.
+
+        If `newer_than` is explicitly passed (even as None), a start-date guard is
+        active: an occupant is only demoted if its `date` is strictly older (by
+        calendar date) than `newer_than`; occupants with a missing date, or a date
+        that is newer-or-equal, are left ONGOING with a warning instead. Omitting
+        `newer_than` entirely preserves the original unconditional behavior relied
+        on by `new_experiments.py` and the legacy create path.
+
+        Args:
+            db: Database session
+            new_experiment: The experiment being created/updated
+            reactor_number: The reactor number being assigned
+            commit: Whether to commit changes (default True)
+            newer_than: Optional start-date guard (see above)
+
+        Returns:
+            Tuple of (marked_completed_count, warnings)
+        """
+        warnings: List[str] = []
+        marked_completed = 0
+        guard_active = newer_than is not _UNSET
+
+        try:
+            if new_experiment.status != ExperimentStatus.ONGOING:
+                return 0, []
+
+            conflicting_experiments = db.query(Experiment).join(
+                ExperimentalConditions,
+                Experiment.id == ExperimentalConditions.experiment_fk
+            ).filter(
+                Experiment.id != new_experiment.id,
+                Experiment.status == ExperimentStatus.ONGOING,
+                ExperimentalConditions.reactor_number == reactor_number
+            ).all()
+
+            for exp in conflicting_experiments:
+                if guard_active:
+                    occ_date = exp.date.date() if exp.date else None
+                    incoming_date = newer_than.date() if newer_than else None
+                    if incoming_date is None or occ_date is None or occ_date >= incoming_date:
+                        warnings.append(
+                            _not_demoted_message(reactor_number, exp.experiment_id, new_experiment.experiment_id)
+                        )
+                        continue
+
+                exp.status = ExperimentStatus.COMPLETED
+                marked_completed += 1
+                warnings.append(
+                    _demoted_message(reactor_number, exp.experiment_id, new_experiment.experiment_id)
+                )
+
+            if commit:
+                db.commit()
+
+        except Exception as e:
+            warnings.append(f"Error managing reactor occupancy: {e}")
+            if commit:
+                db.rollback()
+
+        return marked_completed, warnings
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run the full bulk_uploads service suite to confirm `new_experiments.py`'s callers are unaffected**
+
+Run: `pytest tests/services/bulk_uploads/ -v`
+Expected: All tests PASS, including `tests/services/bulk_uploads/test_new_experiments.py` (uses `manage_reactor_occupancy` without `newer_than`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/services/bulk_uploads/experiment_status.py tests/services/bulk_uploads/test_experiment_status.py
+git commit -m "$(cat <<'EOF'
+[#66] Add optional start-date guard to reactor occupancy
+
+- Tests added: yes
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 4: Apply — per-row writes + demotion execution
+
+**Files:**
+- Modify: `backend/services/bulk_uploads/experiment_status.py` (add `ApplyResult` dataclass, rewrite `apply_status_changes`)
+- Test: `tests/services/bulk_uploads/test_experiment_status.py` (append apply-section tests)
+
+**Interfaces:**
+- Consumes: `StatusChangePreview`, `PlannedChange`, `_is_eligible_for_occupancy` from Task 1; `manage_reactor_occupancy(..., newer_than=...)` from Task 3.
+- Produces: `ApplyResult` dataclass (`status_changes_applied: int`, `demotions_applied: int`, `reactor_updates: int`, `date_updates: int`, `warnings: List[str]`, `errors: List[str]`), `ExperimentStatusService.apply_status_changes(db: Session, preview: StatusChangePreview) -> ApplyResult`. This **replaces** the old `(db, experiment_ids_to_ongoing, reactor_number_map) -> Tuple[int, int, int, List[str]]` signature — Task 5 updates the router call site.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/services/bulk_uploads/test_experiment_status.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "status,exp_num",
+    [("ONGOING", 6700), ("COMPLETED", 6701), ("CANCELLED", 6702), ("QUEUED", 6703)],
+)
+def test_apply_sets_each_status_value(db_session: Session, status: str, exp_num: int):
+    exp = _seed_experiment(db_session, f"HPHT_ST_{status}", exp_num, ExperimentStatus.ONGOING, "HPHT")
+
+    xlsx = make_excel(["experiment_id", "status"], [[exp.experiment_id, status]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert preview.errors == []
+
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.errors == []
+    assert result.status_changes_applied == 1
+    db_session.refresh(exp)
+    assert exp.status == ExperimentStatus(status)
+
+
+def test_apply_writes_date_when_provided(db_session: Session):
+    exp = _seed_experiment(db_session, "HPHT_ST030", 6640, ExperimentStatus.ONGOING, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "date"],
+        [["HPHT_ST030", "ONGOING", "2026-03-15"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.date_updates == 1
+    db_session.refresh(exp)
+    assert exp.date.date().isoformat() == "2026-03-15"
+
+
+def test_apply_leaves_date_untouched_when_absent(db_session: Session):
+    from datetime import datetime
+
+    exp = _seed_experiment(
+        db_session, "HPHT_ST031", 6641, ExperimentStatus.ONGOING, "HPHT", date=datetime(2026, 1, 1),
+    )
+
+    xlsx = make_excel(["experiment_id", "status"], [["HPHT_ST031", "COMPLETED"]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.date_updates == 0
+    db_session.refresh(exp)
+    assert exp.date == datetime(2026, 1, 1)
+
+
+def test_apply_updates_reactor_number_when_provided(db_session: Session):
+    exp = _seed_experiment(
+        db_session, "HPHT_ST032", 6642, ExperimentStatus.ONGOING, "HPHT", reactor_number=1,
+    )
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST032", "ONGOING", 9]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.reactor_updates == 1
+    db_session.refresh(exp)
+    assert exp.conditions.reactor_number == 9
+
+
+def test_apply_triggers_demotion_for_ongoing_hpht_with_older_occupant(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST033", 6643, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=15, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(db_session, "HPHT_ST034", 6644, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST034", "ONGOING", 15, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.demotions_applied == 1
+    db_session.refresh(occupant)
+    db_session.refresh(new_exp)
+    assert occupant.status == ExperimentStatus.COMPLETED
+    assert new_exp.status == ExperimentStatus.ONGOING
+
+
+def test_apply_no_demotion_for_serum_type_even_with_reactor_number(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "Serum_ST005", 6645, ExperimentStatus.ONGOING, "Serum",
+        reactor_number=16, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(db_session, "Serum_ST006", 6646, ExperimentStatus.COMPLETED, "Serum")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["Serum_ST006", "ONGOING", 16, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.demotions_applied == 0
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.ONGOING
+
+
+def test_apply_does_not_touch_unlisted_ongoing_experiment(db_session: Session):
+    """The retired 'complete every unlisted ongoing HPHT' behavior must not fire."""
+    unlisted = _seed_experiment(db_session, "HPHT_ST035", 6647, ExperimentStatus.ONGOING, "HPHT")
+    listed = _seed_experiment(db_session, "HPHT_ST036", 6648, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(["experiment_id", "status"], [["HPHT_ST036", "ONGOING"]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    db_session.refresh(unlisted)
+    assert unlisted.status == ExperimentStatus.ONGOING
+
+
+def test_full_round_trip_file_to_db_state(db_session: Session):
+    """Full round-trip: file → preview → apply → DB state correct, including a demotion."""
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST037", 6649, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=5, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(db_session, "HPHT_ST038", 6650, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST038", "ONGOING", 5, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert preview.errors == []
+
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.errors == []
+    assert result.status_changes_applied == 1
+    assert result.demotions_applied == 1
+    db_session.refresh(new_exp)
+    db_session.refresh(occupant)
+    assert new_exp.status == ExperimentStatus.ONGOING
+    assert new_exp.date.date().isoformat() == "2026-06-01"
+    assert occupant.status == ExperimentStatus.COMPLETED
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v -k apply or round_trip`
+Expected: FAIL — `apply_status_changes()` still expects `(db, experiment_ids_to_ongoing, reactor_number_map)`, not a `StatusChangePreview`.
+
+- [ ] **Step 3: Replace `apply_status_changes` and add `ApplyResult`**
+
+Add the `ApplyResult` dataclass directly below `StatusChangePreview`:
+
+```python
+@dataclass
+class ApplyResult:
+    """Outcome of applying a StatusChangePreview."""
+    status_changes_applied: int
+    demotions_applied: int
+    reactor_updates: int
+    date_updates: int
+    warnings: List[str]
+    errors: List[str]
+```
+
+Replace the entire `apply_status_changes` method with:
+
+```python
+    @staticmethod
+    def apply_status_changes(
+        db: Session,
+        preview: StatusChangePreview,
+    ) -> ApplyResult:
+        """
+        Apply a StatusChangePreview: set each row's status/date/reactor_number,
+        then run reactor-occupancy demotion for eligible ONGOING rows.
+
+        Args:
+            db: Database session
+            preview: The StatusChangePreview returned by preview_status_changes_from_excel
+
+        Returns:
+            ApplyResult with counts and any warnings/errors encountered.
+        """
+        errors: List[str] = []
+        warnings: List[str] = []
+        status_changes = 0
+        date_updates = 0
+        reactor_updates = 0
+        demotions_applied = 0
+
+        try:
+            exp_ids = [c.experiment_id for c in preview.changes]
+            exps = db.query(Experiment).outerjoin(
+                ExperimentalConditions,
+                Experiment.id == ExperimentalConditions.experiment_fk,
+            ).filter(Experiment.experiment_id.in_(exp_ids)).all() if exp_ids else []
+            exp_by_id = {e.experiment_id: e for e in exps}
+
+            for change in preview.changes:
+                exp = exp_by_id.get(change.experiment_id)
+                if exp is None:
+                    continue
+
+                exp.status = ExperimentStatus(change.new_status)
+                status_changes += 1
+
+                if change.new_date is not None:
+                    exp.date = change.new_date.to_pydatetime()
+                    date_updates += 1
+
+                if change.new_reactor_number is not None and exp.conditions:
+                    if exp.conditions.reactor_number != change.new_reactor_number:
+                        exp.conditions.reactor_number = change.new_reactor_number
+                        reactor_updates += 1
+
+                if (
+                    change.new_status == ExperimentStatus.ONGOING.value
+                    and change.new_reactor_number is not None
+                    and _is_eligible_for_occupancy(change.experiment_type)
+                ):
+                    newer_than = change.new_date.to_pydatetime() if change.new_date is not None else None
+                    marked, occ_warnings = ExperimentStatusService.manage_reactor_occupancy(
+                        db, exp, change.new_reactor_number, commit=False, newer_than=newer_than,
+                    )
+                    demotions_applied += marked
+                    warnings.extend(occ_warnings)
+
+        except Exception as e:
+            errors.append(f"Error applying status changes: {e}")
+
+        return ApplyResult(
+            status_changes_applied=status_changes,
+            demotions_applied=demotions_applied,
+            reactor_updates=reactor_updates,
+            date_updates=date_updates,
+            warnings=warnings,
+            errors=errors,
+        )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/services/bulk_uploads/test_experiment_status.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/bulk_uploads/experiment_status.py tests/services/bulk_uploads/test_experiment_status.py
+git commit -m "$(cat <<'EOF'
+[#66] Apply per-row status changes and reactor demotions
+
+- Tests added: yes
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 5: Router — wire the new preview/apply shapes
+
+**Files:**
+- Modify: `backend/api/routers/bulk_uploads.py:580-626` (`upload_experiment_status`)
+- Test: `tests/api/test_bulk_uploads.py:315-336` (`test_experiment_status_returns_upload_response_shape`)
+
+**Interfaces:**
+- Consumes: `ExperimentStatusService.preview_status_changes_from_excel`, `ExperimentStatusService.apply_status_changes` (Tasks 1–4), `UploadResponse` (`backend/api/schemas/bulk_upload.py` — unchanged, already has `warnings: list[str] = []`).
+
+- [ ] **Step 1: Update the failing router test**
+
+In `tests/api/test_bulk_uploads.py`, replace `test_experiment_status_returns_upload_response_shape` (currently ~line 315) with:
+
+```python
+def test_experiment_status_returns_upload_response_shape(client):
+    mock_preview = MagicMock()
+    mock_preview.errors = []
+    mock_preview.missing_ids = []
+
+    mock_result = MagicMock()
+    mock_result.status_changes_applied = 0
+    mock_result.demotions_applied = 0
+    mock_result.reactor_updates = 0
+    mock_result.date_updates = 0
+    mock_result.warnings = []
+    mock_result.errors = []
+
+    mock_svc = MagicMock()
+    mock_svc.preview_status_changes_from_excel.return_value = mock_preview
+    mock_svc.apply_status_changes.return_value = mock_result
+    fake_mod = MagicMock()
+    fake_mod.ExperimentStatusService = mock_svc
+
+    with patch.dict(sys.modules, {
+        "backend.services.bulk_uploads.experiment_status": fake_mod,
+    }):
+        resp = client.post(
+            "/api/bulk-uploads/experiment-status",
+            files={"file": ("status.xlsx", io.BytesIO(b"fake"), "application/vnd.ms-excel")},
+        )
+    assert resp.status_code == 200
+    _assert_upload_shape(resp.json())
+```
+
+Run: `pytest tests/api/test_bulk_uploads.py -v -k experiment_status`
+Expected: FAIL — router still calls `apply_status_changes(db, to_ongoing_ids, reactor_map)` with the old 3-arg signature and reads `preview.to_ongoing`, which the mock no longer provides.
+
+- [ ] **Step 2: Rewrite the router endpoint**
+
+In `backend/api/routers/bulk_uploads.py`, replace the entire `upload_experiment_status` function (currently lines 580–626) with:
+
+```python
+@router.post("/experiment-status", response_model=UploadResponse)
+async def upload_experiment_status(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: FirebaseUser = Depends(verify_firebase_token),
+) -> UploadResponse:
+    """Upload an Experiment Status Excel file (per-row status/date/reactor updates)."""
+    from backend.services.bulk_uploads.experiment_status import ExperimentStatusService  # noqa: PLC0415
+    file_bytes = await file.read()
+    try:
+        preview = ExperimentStatusService.preview_status_changes_from_excel(db, file_bytes)
+        if preview.errors:
+            return UploadResponse(
+                created=0, updated=0, skipped=len(preview.missing_ids),
+                errors=preview.errors,
+                message="Validation failed — no changes applied",
+            )
+        result = ExperimentStatusService.apply_status_changes(db, preview)
+        if not result.errors:
+            db.commit()
+        else:
+            db.rollback()
+    except Exception as exc:
+        db.rollback()
+        log.error("experiment_status_upload_failed", error=str(exc))
+        return UploadResponse(created=0, updated=0, skipped=0, errors=[str(exc)],
+                              message="Upload failed")
+    return UploadResponse(
+        created=0,
+        updated=result.status_changes_applied,
+        skipped=len(preview.missing_ids),
+        errors=result.errors,
+        warnings=result.warnings,
+        feedbacks=[{
+            "status_changes": result.status_changes_applied,
+            "demotions": result.demotions_applied,
+            "reactor_updates": result.reactor_updates,
+            "date_updates": result.date_updates,
+        }],
+        message=(
+            f"Status update: {result.status_changes_applied} row(s) applied, "
+            f"{result.demotions_applied} reactor demotion(s), "
+            f"{len(preview.missing_ids)} not found"
+        ),
+    )
+```
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `pytest tests/api/test_bulk_uploads.py -v`
+Expected: All tests PASS (this includes the parametrized auth/file-required tests at lines ~356 and ~391, which already reference `/api/bulk-uploads/experiment-status` and are unaffected by the body rewrite).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/api/routers/bulk_uploads.py tests/api/test_bulk_uploads.py
+git commit -m "$(cat <<'EOF'
+[#66] Wire per-row status endpoint to new service shapes
+
+- Tests added: yes
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 6: Template — 4 columns + INSTRUCTIONS sheet
+
+**Files:**
+- Modify: `backend/api/routers/bulk_uploads.py:988-993` (`_get_template_bytes`, `"experiment-status"` branch)
+- Test: `tests/api/test_bulk_uploads.py` (append a template-content test)
+
+**Interfaces:**
+- Consumes: nothing new — `_get_template_bytes(upload_type, mode=None) -> bytes` keeps its existing signature; only the `"experiment-status"` branch's body changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/api/test_bulk_uploads.py` (near the other template tests, after `test_template_download_returns_xlsx`):
+
+```python
+def test_experiment_status_template_has_four_columns_and_instructions(client):
+    import openpyxl
+
+    resp = client.get("/api/bulk-uploads/templates/experiment-status")
+    assert resp.status_code == 200
+
+    wb = openpyxl.load_workbook(io.BytesIO(resp.content))
+    ws = wb["Template"]
+    headers = [c.value for c in ws[1]]
+    assert headers == ["experiment_id", "status", "reactor_number", "date"]
+    assert ws.cell(row=2, column=1).value == "HPHT_072"
+    assert ws.cell(row=2, column=2).value == "ONGOING"
+
+    assert "INSTRUCTIONS" in wb.sheetnames
+    inst_col_a = [c.value for c in wb["INSTRUCTIONS"]["A"] if c.value]
+    assert "status" in inst_col_a
+    assert "date" in inst_col_a
+```
+
+Run: `pytest tests/api/test_bulk_uploads.py -v -k experiment_status_template`
+Expected: FAIL — `KeyError: 'INSTRUCTIONS'` (current template is a 2-column `_simple_template` call with no INSTRUCTIONS sheet).
+
+- [ ] **Step 2: Rewrite the template branch**
+
+In `backend/api/routers/bulk_uploads.py`, replace:
+
+```python
+    if upload_type == "experiment-status":
+        return _simple_template(
+            headers=["experiment_id", "reactor_number"],
+            required={"experiment_id"},
+            example_row=["HPHT_072", 3],
+        )
+```
+
+with:
+
+```python
+    if upload_type == "experiment-status":
+        import openpyxl  # noqa: PLC0415
+        from openpyxl.styles import PatternFill, Font, Alignment  # noqa: PLC0415
+
+        headers = ["experiment_id", "status", "reactor_number", "date"]
+        required = {"experiment_id", "status"}
+        example_row = ["HPHT_072", "ONGOING", 3, "2026-07-15"]
+        req_fill = PatternFill(start_color="FFD700", end_color="FFD700", fill_type="solid")
+        opt_fill = PatternFill(start_color="E2EFDA", end_color="E2EFDA", fill_type="solid")
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Template"
+        for col, h in enumerate(headers, start=1):
+            cell = ws.cell(row=1, column=col, value=h)
+            cell.font = Font(bold=True)
+            cell.fill = req_fill if h in required else opt_fill
+            cell.alignment = Alignment(horizontal="center")
+            ws.column_dimensions[cell.column_letter].width = max(len(h) + 4, 18)
+        for col, val in enumerate(example_row, start=1):
+            ws.cell(row=2, column=col, value=val)
+
+        ws_inst = wb.create_sheet("INSTRUCTIONS")
+        ws_inst.column_dimensions["A"].width = 30
+        ws_inst.column_dimensions["B"].width = 80
+        instructions = [
+            ("Column", "Notes"),
+            ("experiment_id", "REQUIRED. Must match an existing experiment_id."),
+            ("status", "REQUIRED. One of ONGOING, COMPLETED, CANCELLED, QUEUED (case-insensitive)."),
+            ("reactor_number", "Integer. Only meaningful for HPHT / Core Flood experiments."),
+            (
+                "date",
+                "Experiment start date (YYYY-MM-DD or Excel date). Used both to set the "
+                "experiment's start date and to decide reactor demotion order.",
+            ),
+            (
+                "Demotion rule",
+                "Setting an HPHT or Core Flood experiment to ONGOING with a reactor_number "
+                "completes an older experiment currently ongoing in the same reactor. If the "
+                "reactor is held by a newer-or-equal-dated experiment (or either start date "
+                "is missing), nothing is demoted and a warning is returned.",
+            ),
+        ]
+        for r_idx, (col_name, note) in enumerate(instructions, start=1):
+            name_cell = ws_inst.cell(row=r_idx, column=1, value=col_name)
+            note_cell = ws_inst.cell(row=r_idx, column=2, value=note)
+            if r_idx == 1:
+                name_cell.font = Font(bold=True)
+                note_cell.font = Font(bold=True)
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        return buf.getvalue()
+```
+
+- [ ] **Step 3: Run the tests to verify they pass**
+
+Run: `pytest tests/api/test_bulk_uploads.py -v`
+Expected: All tests PASS, including the pre-existing `test_template_download_returns_xlsx[experiment-status]` parametrization.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/api/routers/bulk_uploads.py tests/api/test_bulk_uploads.py
+git commit -m "$(cat <<'EOF'
+[#66] Regenerate experiment-status template with 4 columns
+
+- Tests added: yes
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 7: Frontend — tile copy update
+
+**Files:**
+- Modify: `frontend/src/pages/BulkUploads.tsx:335-346`
+
+**Interfaces:**
+- Consumes: nothing (copy-only change). The tile already renders `result.warnings` generically via `frontend/src/pages/BulkUploadRow.tsx` (confirmed present at lines ~224 and ~253–268) — no component change needed there.
+
+- [ ] **Step 1: Update the tile copy**
+
+In `frontend/src/pages/BulkUploads.tsx`, replace:
+
+```tsx
+        {/* 11 — Experiment Status Update */}
+        <UploadRow
+          id="experiment-status"
+          title="Experiment Status Update"
+          description="Bulk-set ONGOING / COMPLETED statuses"
+          helpText="Required column: experiment_id. Listed experiments are set to ONGOING; other HPHT experiments currently ONGOING are set to COMPLETED. Optional: reactor_number column."
+          accept=".xlsx,.xls,.csv"
+          uploadFn={(file) => bulkUploadsApi.uploadExperimentStatus(file)}
+          templateType="experiment-status"
+          isOpen={isOpen('experiment-status')}
+          onToggle={() => toggle('experiment-status')}
+        />
+```
+
+with:
+
+```tsx
+        {/* 11 — Experiment Status Update */}
+        <UploadRow
+          id="experiment-status"
+          title="Experiment Status Update"
+          description="Bulk-set experiment status (ONGOING / COMPLETED / QUEUED / CANCELLED)"
+          helpText="Required columns: experiment_id, status. Optional: reactor_number, date (start date). Setting an HPHT or Core Flood experiment to ONGOING with a reactor_number auto-completes an older experiment in the same reactor; a newer-or-equal-dated occupant triggers a warning instead of a completion."
+          accept=".xlsx,.xls,.csv"
+          uploadFn={(file) => bulkUploadsApi.uploadExperimentStatus(file)}
+          templateType="experiment-status"
+          isOpen={isOpen('experiment-status')}
+          onToggle={() => toggle('experiment-status')}
+        />
+```
+
+- [ ] **Step 2: Verify no frontend unit test targets this copy**
+
+Run: `cd frontend && npx vitest run src -t "experiment"`
+Expected: PASS or no matching tests found (no existing test asserts on this tile's copy strings — confirmed via `grep -r "Bulk-set ONGOING" frontend/src` returning no test-file matches).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/BulkUploads.tsx
+git commit -m "$(cat <<'EOF'
+[#66] Update Experiment Status tile copy for per-row model
+
+- Tests added: no
+- Docs updated: no
+EOF
+)"
+```
+
+---
+
+### Task 8: Documentation + final verification
+
+**Files:**
+- Modify: `docs/api/API_REFERENCE.md:280-282` (endpoint row + template row)
+- Modify: `docs/user_guide/BULK_UPLOADS.md:269-290` (section "11 — Experiment Status Update")
+
+**Interfaces:** none (documentation only). The `PostToolUse` hook auto-copies both files into `docs/project_context/` after each `Write`/`Edit` — do not write to `docs/project_context/` directly.
+
+- [ ] **Step 1: Update `docs/api/API_REFERENCE.md`**
+
+Replace the line (currently ~280):
+
+```
+| POST | `/api/bulk-uploads/experiment-status` | Preview + apply bulk ONGOING/COMPLETED transitions. |
+```
+
+with:
+
+```
+| POST | `/api/bulk-uploads/experiment-status` | Per-row status/date/reactor update. HPHT/Core Flood rows set to ONGOING with a reactor_number auto-complete an older occupant in the same reactor (date-gated); no blanket "complete unlisted HPHT" behavior. |
+```
+
+- [ ] **Step 2: Rewrite `docs/user_guide/BULK_UPLOADS.md` section 11**
+
+Replace the entire section (currently lines 269–290, from `## 11 — Experiment Status Update` through the line before `## 12 — pXRF Readings`):
+
+```markdown
+## 11 — Experiment Status Update
+
+**Endpoint:** `POST /api/bulk-uploads/experiment-status`
+**Template:** available
+
+Set each experiment's status explicitly, per row. Applies to experiments of any
+type — Serum, Autoclave, HPHT, Core Flood.
+
+Logic:
+- Each row sets its own `status` (`ONGOING`, `COMPLETED`, `CANCELLED`, or `QUEUED`; case-insensitive).
+- If `date` is provided, it updates the experiment's start date (`Experiment.date`).
+- If `reactor_number` is provided, it updates `ExperimentalConditions.reactor_number`.
+- Setting an **HPHT or Core Flood** row to `ONGOING` with a `reactor_number` completes
+  an experiment already `ONGOING` in that same reactor, **only if** the occupant's
+  start date is older than the incoming row's start date.
+- If the reactor is held by a newer-or-equal-dated experiment (or either date is
+  missing), nothing is demoted and a warning names both experiments and the reactor.
+- Experiment IDs not found in the database are reported as `missing_ids`.
+- There is no blanket "complete every unlisted ongoing HPHT" behavior — an
+  experiment not referenced in the file is never touched.
+- Invalid `status`/`reactor_number`/`date` values, or two rows targeting the same
+  `reactor_number`, hard-fail the whole upload with no changes applied. A missing
+  `experiment_id` or `status` column does the same.
+
+The endpoint runs preview validation and apply in one request (no separate
+confirm step): upload the file and the response reports what was applied.
+
+| Column | Required | Notes |
+|--------|----------|-------|
+| experiment_id | ✓ | |
+| status | ✓ | ONGOING, COMPLETED, CANCELLED, or QUEUED (case-insensitive) |
+| reactor_number | | Optional; only meaningful for HPHT / Core Flood experiments |
+| date | | Optional; experiment start date (YYYY-MM-DD or Excel date) |
+
+---
+```
+
+- [ ] **Step 3: Run the full backend and frontend test suites**
+
+Run: `pytest tests/ -v --ignore=tests/test_pg_backup_restore.py`
+Expected: All PASS (the ignored file requires a live `experiments_restore_test` Postgres instance — a pre-existing, unrelated infra dependency per `docs/working/plan.md`'s M8 notes).
+
+Run: `cd frontend && npx vitest run src`
+Expected: All PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/api/API_REFERENCE.md docs/user_guide/BULK_UPLOADS.md docs/project_context/API_REFERENCE.md docs/project_context/BULK_UPLOADS.md
+git commit -m "$(cat <<'EOF'
+[#66] Document per-row experiment status upload
+
+- Tests added: no
+- Docs updated: yes
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Template (Task 6), per-row parse/validate (Task 1), demotion planning + execution (Tasks 2–4), reactor helper guard + backward compatibility (Task 3), router (Task 5), frontend copy (Task 7), all four confirmed open items (Global Constraints + Tasks 1–4 tests), all Testing-section bullet points (per-row status × 4 values, date write/untouched, HPHT + Core Flood demotion, newer/equal/missing-date warnings, unlisted-never-touched, invalid-row errors, missing-column hard errors, same-reactor-two-rows, `manage_reactor_occupancy` regression), docs (Task 8).
+- **Out of scope, confirmed not touched:** `new_experiments.py` logic itself (only its dependency, `manage_reactor_occupancy`, gains a parameter it never passes), reactor-number validation against a canonical registry, legacy Streamlit create path, `experiment_type` enum migration.
+- **Type consistency check:** `PlannedChange.experiment_type` (Task 1) is read by `_is_eligible_for_occupancy` in both preview (Task 2) and apply (Task 4) — same function, same input type (`str | None`). `ApplyResult` fields (Task 4) match exactly what the router (Task 5) reads: `status_changes_applied`, `demotions_applied`, `reactor_updates`, `date_updates`, `warnings`, `errors`. `StatusChangePreview.errors`/`.missing_ids` (Task 1) are what the router checks before calling apply — unchanged shape through all tasks.

--- a/docs/upload_templates/experiment_status.md
+++ b/docs/upload_templates/experiment_status.md
@@ -3,7 +3,7 @@
 **Source:** [backend/services/bulk_uploads/experiment_status.py](../../backend/services/bulk_uploads/experiment_status.py)
 
 ## Overview
-Allows for bulk updating of experiment statuses, specifically marking active experiments as `ONGOING` and automatically handling the transition of unlisted HPHT experiments to `COMPLETED`.
+Allows bulk updating of experiment statuses on a per-row basis: each row sets an explicit `status` (`ONGOING`, `COMPLETED`, `CANCELLED`, or `QUEUED`) for one experiment. Applies to experiments of any type — Serum, Autoclave, HPHT, Core Flood. There is no blanket "complete every unlisted ongoing HPHT" behavior — an experiment not referenced in the file is never touched.
 
 ## Excel Format
 - **Target Sheet:** Reads from a single sheet.
@@ -12,27 +12,33 @@ Allows for bulk updating of experiment statuses, specifically marking active exp
 
 ### Required Columns
 - `experiment_id`
+- `status`: one of `ONGOING`, `COMPLETED`, `CANCELLED`, `QUEUED` (case-insensitive)
 
 ### Optional Columns
-- `reactor_number`
+- `reactor_number`: only meaningful for HPHT / Core Flood experiments
+- `date`: experiment start date (`YYYY-MM-DD` or Excel date). Also used to decide reactor demotion order.
 
 ## Parsing Logic
 - **Headers:** Evaluated case-insensitively.
-- **Experiment IDs:** Compiles a list of unique `experiment_id`s that should be marked as `ONGOING`.
-- **Reactor Numbers:** Parses the optional `reactor_number` per row, storing it in a mapping dictionary for later application to the experiment's conditions.
+- **Rows:** Each row is parsed independently into a planned change (`experiment_id`, `status`, optional `reactor_number`, optional `date`). Invalid `status`/`reactor_number`/`date` values produce a row-level error.
+- **Missing required columns:** A missing `experiment_id` or `status` column hard-fails the whole upload with no changes applied.
+- **Same-reactor conflict:** If two rows both set an HPHT/Core-Flood-eligible experiment to `ONGOING` in the same `reactor_number`, the file is rejected as internally inconsistent.
 
 ## Behavior and Flow
 
 ### Preview Phase (`preview_status_changes_from_excel`)
 Generates a `StatusChangePreview` object that includes:
-- Experiments to be set to `ONGOING` (from the uploaded file).
-- Experiments to be set to `COMPLETED` (currently `ONGOING` HPHT experiments that are *not* present in the uploaded file).
-- Missing IDs and validation errors.
+- `changes`: planned per-row status/date/reactor changes (`PlannedChange` list).
+- `demotions`: planned reactor demotions (`PlannedDemotion` list) — for HPHT/Core-Flood-eligible rows set to `ONGOING` with a `reactor_number`, where an older same-reactor occupant exists.
+- `missing_ids`: experiment IDs from the file not found in the database.
+- `errors`: column/row-level validation errors and same-reactor conflicts (any non-empty `errors` blocks the whole upload).
+- `warnings`: explanatory notes, including cases where a same-reactor occupant is *not* demoted (newer-or-equal start date, or a missing start date on either side).
 
 ### Application Phase (`apply_status_changes`)
-- Sets the listed experiments to `ONGOING`.
-- Sets the unlisted `ONGOING` experiments to `COMPLETED`.
-- Updates the `reactor_number` in `ExperimentalConditions` when a value is provided in the upload.
+- Sets each row's `status` on its experiment.
+- Writes `date` to the experiment's start date when provided.
+- Updates `reactor_number` in `ExperimentalConditions` when provided and different from the current value.
+- For eligible ONGOING rows with a `reactor_number`, executes the planned demotion via `manage_reactor_occupancy` (only demotes an occupant whose start date is strictly older; otherwise leaves it `ONGOING` with a warning).
 
 ## Output
-The apply step returns a tuple: `(marked_ongoing, marked_completed, reactor_updates, errors)`.
+The apply step returns an `ApplyResult` with fields: `status_changes_applied`, `demotions_applied`, `reactor_updates`, `date_updates`, `warnings`, `errors`.

--- a/docs/user_guide/BULK_UPLOADS.md
+++ b/docs/user_guide/BULK_UPLOADS.md
@@ -271,22 +271,34 @@ No template available — upload the ActLabs-exported file directly.
 **Endpoint:** `POST /api/bulk-uploads/experiment-status`
 **Template:** available
 
-Preview and apply bulk experiment status transitions (ONGOING / COMPLETED).
+Set each experiment's status explicitly, per row. Applies to experiments of any
+type — Serum, Autoclave, HPHT, Core Flood.
 
 Logic:
-- All experiments listed in the file are moved to **ONGOING**
-- All ONGOING experiments with HPHT conditions **not** in the file are moved to **COMPLETED**
-- Experiment IDs not found in the database are reported as `missing_ids`
+- Each row sets its own `status` (`ONGOING`, `COMPLETED`, `CANCELLED`, or `QUEUED`; case-insensitive).
+- If `date` is provided, it updates the experiment's start date (`Experiment.date`).
+- If `reactor_number` is provided, it updates `ExperimentalConditions.reactor_number`.
+- Setting an **HPHT or Core Flood** row to `ONGOING` with a `reactor_number` completes
+  an experiment already `ONGOING` in that same reactor, **only if** the occupant's
+  start date is older than the incoming row's start date.
+- If the reactor is held by a newer-or-equal-dated experiment (or either date is
+  missing), nothing is demoted and a warning names both experiments and the reactor.
+- Experiment IDs not found in the database are reported as `missing_ids`.
+- There is no blanket "complete every unlisted ongoing HPHT" behavior — an
+  experiment not referenced in the file is never touched.
+- Invalid `status`/`reactor_number`/`date` values, or two rows targeting the same
+  `reactor_number`, hard-fail the whole upload with no changes applied. A missing
+  `experiment_id` or `status` column does the same.
 
-The endpoint uses a two-phase preview → apply workflow:
-1. Upload the file to see a preview of what will change
-2. The UI displays the pending changes; user confirms
-3. Changes are applied atomically
+The endpoint runs preview validation and apply in one request (no separate
+confirm step): upload the file and the response reports what was applied.
 
 | Column | Required | Notes |
 |--------|----------|-------|
 | experiment_id | ✓ | |
-| reactor_number | | Optional; updates the reactor assignment if provided |
+| status | ✓ | ONGOING, COMPLETED, CANCELLED, or QUEUED (case-insensitive) |
+| reactor_number | | Optional; only meaningful for HPHT / Core Flood experiments |
+| date | | Optional; experiment start date (YYYY-MM-DD or Excel date) |
 
 ---
 

--- a/frontend/src/pages/BulkUploads.tsx
+++ b/frontend/src/pages/BulkUploads.tsx
@@ -336,8 +336,8 @@ export function BulkUploadsPage() {
         <UploadRow
           id="experiment-status"
           title="Experiment Status Update"
-          description="Bulk-set ONGOING / COMPLETED statuses"
-          helpText="Required column: experiment_id. Listed experiments are set to ONGOING; other HPHT experiments currently ONGOING are set to COMPLETED. Optional: reactor_number column."
+          description="Bulk-set experiment status (ONGOING / COMPLETED / QUEUED / CANCELLED)"
+          helpText="Required columns: experiment_id, status. Optional: reactor_number, date (start date). Setting an HPHT or Core Flood experiment to ONGOING with a reactor_number auto-completes an older experiment in the same reactor; a newer-or-equal-dated occupant triggers a warning instead of a completion."
           accept=".xlsx,.xls,.csv"
           uploadFn={(file) => bulkUploadsApi.uploadExperimentStatus(file)}
           templateType="experiment-status"

--- a/legacy/streamlit_frontend/bulk_uploads.py
+++ b/legacy/streamlit_frontend/bulk_uploads.py
@@ -1692,37 +1692,43 @@ def _process_icp_csv(
 
 def handle_experiment_status_update():
     """
-    Bulk update experiment status: mark listed experiments as ONGOING,
-    mark all other ONGOING experiments as COMPLETED.
+    Bulk update experiment status per row: each row sets an explicit status
+    (ONGOING/COMPLETED/CANCELLED/QUEUED); HPHT/Core Flood rows set to ONGOING
+    with a reactor_number demote an older same-reactor occupant (date-gated).
     Shows preview before applying changes with confirmation required.
     """
     st.header("Bulk Update Experiment Status")
+
     st.markdown("""
-    Upload an Excel file with experiment IDs to mark as **ONGOING**. 
-    All other **HPHT** experiments currently marked as **ONGOING** will be changed to **COMPLETED**.
-    
+    Upload an Excel file with one row per experiment status change.
+
     **Columns:**
-    - `experiment_id` (required): Experiments to mark as ONGOING
-    - `reactor_number` (optional): Update reactor number for HPHT experiments
-    
+    - `experiment_id` (required)
+    - `status` (required): ONGOING, COMPLETED, CANCELLED, or QUEUED (case-insensitive)
+    - `reactor_number` (optional): only meaningful for HPHT / Core Flood experiments
+    - `date` (optional): experiment start date; also used to decide reactor demotion order
+
     **Important Notes:**
-    - Only HPHT experiments not in the list will be auto-completed
-    - Other experiment types (Serum, Autoclave, etc.) maintain their status
+    - Setting an HPHT or Core Flood experiment to ONGOING with a reactor_number completes
+      an older experiment currently ongoing in the same reactor — only if that occupant's
+      start date is older. If the reactor is held by a newer-or-equal-dated experiment (or
+      either date is missing), nothing is demoted and a warning is shown instead.
+    - An experiment not listed in the file is never touched.
     - You will see a preview before any changes are applied
     - Confirmation is required before applying changes
     """)
 
     # Generate template
     template_df = pd.DataFrame([
-        {"experiment_id": "HPHT_MH_001", "reactor_number": 1},
-        {"experiment_id": "HPHT_MH_002", "reactor_number": 2},
-        {"experiment_id": "Serum_JD_015", "reactor_number": ""},
-    ], columns=["experiment_id", "reactor_number"])
+        {"experiment_id": "HPHT_MH_001", "status": "ONGOING", "reactor_number": 1, "date": "2026-07-15"},
+        {"experiment_id": "HPHT_MH_002", "status": "COMPLETED", "reactor_number": "", "date": ""},
+        {"experiment_id": "Serum_JD_015", "status": "QUEUED", "reactor_number": "", "date": ""},
+    ], columns=["experiment_id", "status", "reactor_number", "date"])
 
     buf = io.BytesIO()
     with pd.ExcelWriter(buf, engine='openpyxl') as writer:
         template_df.to_excel(writer, index=False, sheet_name='experiment_status')
-        
+
         # Autosize columns for readability
         try:
             from frontend.components.utils import autosize_excel_columns
@@ -1739,7 +1745,7 @@ def handle_experiment_status_update():
     )
 
     st.markdown("---")
-    
+
     # File uploader
     uploaded_file = st.file_uploader("Upload filled template (xlsx)", type=["xlsx"], key="status_upload")
 
@@ -1750,99 +1756,98 @@ def handle_experiment_status_update():
     db = SessionLocal()
     try:
         preview = ExperimentStatusService.preview_status_changes_from_excel(db, uploaded_file.read())
-        
+
         # Show errors if any
         if preview.errors:
             st.error("Validation errors found:")
             for error in preview.errors:
                 st.error(error)
             return
-        
+
         # Show missing IDs warning
         if preview.missing_ids:
             st.warning(f"⚠️ {len(preview.missing_ids)} experiment ID(s) not found in database:")
             missing_df = pd.DataFrame({"Missing Experiment IDs": preview.missing_ids})
             st.dataframe(missing_df, use_container_width=True)
             st.info("These IDs will be skipped. Only experiments found in the database will be processed.")
-        
+
         # Show preview of changes
         st.subheader("📋 Preview of Changes")
-        
-        col1, col2 = st.columns(2)
-        
-        with col1:
-            st.metric("Experiments → ONGOING", len(preview.to_ongoing))
-            if preview.to_ongoing:
-                st.write("**Will be marked as ONGOING:**")
-                ongoing_df = pd.DataFrame(preview.to_ongoing)
-                # Reorder columns for better display
-                col_order = ['experiment_id', 'current_status', 'current_reactor_number', 'new_reactor_number']
-                ongoing_df = ongoing_df[[col for col in col_order if col in ongoing_df.columns]]
-                st.dataframe(ongoing_df, use_container_width=True)
-        
-        with col2:
-            st.metric("Experiments → COMPLETED", len(preview.to_completed))
-            if preview.to_completed:
-                st.write("**Will be marked as COMPLETED (HPHT only):**")
-                completed_df = pd.DataFrame(preview.to_completed)
-                # Reorder columns for better display
-                col_order = ['experiment_id', 'current_status', 'current_reactor_number']
-                completed_df = completed_df[[col for col in col_order if col in completed_df.columns]]
-                st.dataframe(completed_df, use_container_width=True)
-        
+
+        st.metric("Experiments to update", len(preview.changes))
+        if preview.changes:
+            changes_df = pd.DataFrame([{
+                "experiment_id": c.experiment_id,
+                "current_status": c.current_status,
+                "new_status": c.new_status,
+                "reactor_number": c.reactor_number,
+                "new_reactor_number": c.new_reactor_number,
+                "new_date": c.new_date.date().isoformat() if c.new_date is not None else None,
+            } for c in preview.changes])
+            st.dataframe(changes_df, use_container_width=True)
+
+        if preview.demotions:
+            st.write("**Reactor demotions that will be applied:**")
+            demotions_df = pd.DataFrame([{
+                "experiment_id": d.experiment_id,
+                "reactor_number": d.reactor_number,
+                "replaced_by": d.triggering_experiment_id,
+            } for d in preview.demotions])
+            st.dataframe(demotions_df, use_container_width=True)
+
+        if preview.warnings:
+            for warning in preview.warnings:
+                st.warning(warning)
+
         # No changes to apply
-        if not preview.to_ongoing and not preview.to_completed:
+        if not preview.changes:
             st.info("ℹ️ No status changes needed based on this file.")
             return
-        
+
         # Confirmation section
         st.markdown("---")
         st.subheader("⚠️ Confirm Changes")
-        
-        total_changes = len(preview.to_ongoing) + len(preview.to_completed)
+
+        total_changes = len(preview.changes)
         st.warning(f"This will update the status of **{total_changes} experiment(s)**. This action cannot be undone through the UI.")
-        
+
         # Confirmation text input
         confirmation_text = st.text_input(
             'Type "CONFIRM" to proceed with status updates:',
             key="status_confirm"
         )
-        
+
         # Apply button (disabled unless confirmation entered)
         apply_disabled = confirmation_text.upper() != "CONFIRM"
-        
+
         if st.button("Apply Status Changes", disabled=apply_disabled, type="primary"):
-            # Extract experiment IDs to mark as ONGOING
-            exp_ids_to_ongoing = [exp["experiment_id"] for exp in preview.to_ongoing]
-            
-            # Get reactor_number_map from preview
-            reactor_number_map = getattr(preview, 'reactor_number_map', {})
-            
-            # Apply changes
-            marked_ongoing, marked_completed, reactor_updates, errors = ExperimentStatusService.apply_status_changes(
-                db, exp_ids_to_ongoing, reactor_number_map
-            )
-            
-            if errors:
+            result = ExperimentStatusService.apply_status_changes(db, preview)
+
+            if result.errors:
                 db.rollback()
                 st.error("Failed to apply status changes:")
-                for error in errors:
+                for error in result.errors:
                     st.error(error)
             else:
                 db.commit()
                 st.success(f"✅ Status changes applied successfully!")
-                st.info(f"**{marked_ongoing}** experiment(s) marked as ONGOING")
-                st.info(f"**{marked_completed}** experiment(s) marked as COMPLETED")
-                if reactor_updates > 0:
-                    st.info(f"**{reactor_updates}** reactor number(s) updated")
-                
+                st.info(f"**{result.status_changes_applied}** experiment(s) updated")
+                if result.demotions_applied > 0:
+                    st.info(f"**{result.demotions_applied}** reactor demotion(s) applied")
+                if result.reactor_updates > 0:
+                    st.info(f"**{result.reactor_updates}** reactor number(s) updated")
+                if result.date_updates > 0:
+                    st.info(f"**{result.date_updates}** start date(s) updated")
+                for warning in result.warnings:
+                    st.info(warning)
+
                 # Clear the confirmation text
                 if 'status_confirm' in st.session_state:
                     del st.session_state['status_confirm']
-        
+
         if apply_disabled and confirmation_text:
             st.info('Please type "CONFIRM" exactly (case-insensitive) to enable the Apply button.')
-            
+
     except Exception as e:
         db.rollback()
         st.error(f"An unexpected error occurred: {e}")

--- a/tests/api/test_bulk_uploads.py
+++ b/tests/api/test_bulk_uploads.py
@@ -552,6 +552,25 @@ def test_new_experiments_template_additives_sheet_headers(client):
         assert required in headers, f"Missing column '{required}' in additives sheet"
 
 
+def test_experiment_status_template_has_four_columns_and_instructions(client):
+    import openpyxl
+
+    resp = client.get("/api/bulk-uploads/templates/experiment-status")
+    assert resp.status_code == 200
+
+    wb = openpyxl.load_workbook(io.BytesIO(resp.content))
+    ws = wb["Template"]
+    headers = [c.value for c in ws[1]]
+    assert headers == ["experiment_id", "status", "reactor_number", "date"]
+    assert ws.cell(row=2, column=1).value == "HPHT_072"
+    assert ws.cell(row=2, column=2).value == "ONGOING"
+
+    assert "INSTRUCTIONS" in wb.sheetnames
+    inst_col_a = [c.value for c in wb["INSTRUCTIONS"]["A"] if c.value]
+    assert "status" in inst_col_a
+    assert "date" in inst_col_a
+
+
 # ── Issue #50: ActLabs conflict response ─────────────────────────────────────
 
 import json

--- a/tests/api/test_bulk_uploads.py
+++ b/tests/api/test_bulk_uploads.py
@@ -366,7 +366,7 @@ def test_experiment_status_validation_errors_skip_apply(client):
     mock_svc.apply_status_changes.assert_not_called()
 
 
-def test_experiment_status_rolls_back_on_apply_errors(client):
+def test_experiment_status_rolls_back_on_apply_errors(client, db_session):
     mock_preview = MagicMock()
     mock_preview.errors = []
     mock_preview.missing_ids = []
@@ -387,7 +387,8 @@ def test_experiment_status_rolls_back_on_apply_errors(client):
 
     with patch.dict(sys.modules, {
         "backend.services.bulk_uploads.experiment_status": fake_mod,
-    }):
+    }), patch.object(db_session, "commit") as mock_commit, \
+            patch.object(db_session, "rollback") as mock_rollback:
         resp = client.post(
             "/api/bulk-uploads/experiment-status",
             files={"file": ("status.xlsx", io.BytesIO(b"fake"), "application/vnd.ms-excel")},
@@ -397,6 +398,8 @@ def test_experiment_status_rolls_back_on_apply_errors(client):
     _assert_upload_shape(body)
     assert "Error applying status changes: boom" in body["errors"]
     assert body["updated"] == 0
+    mock_rollback.assert_called_once()
+    mock_commit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_bulk_uploads.py
+++ b/tests/api/test_bulk_uploads.py
@@ -315,13 +315,19 @@ def test_actlabs_rock_returns_upload_response_shape(client):
 def test_experiment_status_returns_upload_response_shape(client):
     mock_preview = MagicMock()
     mock_preview.errors = []
-    mock_preview.to_ongoing = []
-    mock_preview.to_completed = []
     mock_preview.missing_ids = []
+
+    mock_result = MagicMock()
+    mock_result.status_changes_applied = 0
+    mock_result.demotions_applied = 0
+    mock_result.reactor_updates = 0
+    mock_result.date_updates = 0
+    mock_result.warnings = []
+    mock_result.errors = []
 
     mock_svc = MagicMock()
     mock_svc.preview_status_changes_from_excel.return_value = mock_preview
-    mock_svc.apply_status_changes.return_value = (0, 0, {}, [])
+    mock_svc.apply_status_changes.return_value = mock_result
     fake_mod = MagicMock()
     fake_mod.ExperimentStatusService = mock_svc
 

--- a/tests/api/test_bulk_uploads.py
+++ b/tests/api/test_bulk_uploads.py
@@ -342,6 +342,63 @@ def test_experiment_status_returns_upload_response_shape(client):
     _assert_upload_shape(resp.json())
 
 
+def test_experiment_status_validation_errors_skip_apply(client):
+    mock_preview = MagicMock()
+    mock_preview.errors = ["Missing required column: 'status'"]
+    mock_preview.missing_ids = []
+
+    mock_svc = MagicMock()
+    mock_svc.preview_status_changes_from_excel.return_value = mock_preview
+    fake_mod = MagicMock()
+    fake_mod.ExperimentStatusService = mock_svc
+
+    with patch.dict(sys.modules, {
+        "backend.services.bulk_uploads.experiment_status": fake_mod,
+    }):
+        resp = client.post(
+            "/api/bulk-uploads/experiment-status",
+            files={"file": ("status.xlsx", io.BytesIO(b"fake"), "application/vnd.ms-excel")},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    _assert_upload_shape(body)
+    assert "Missing required column: 'status'" in body["errors"]
+    mock_svc.apply_status_changes.assert_not_called()
+
+
+def test_experiment_status_rolls_back_on_apply_errors(client):
+    mock_preview = MagicMock()
+    mock_preview.errors = []
+    mock_preview.missing_ids = []
+
+    mock_result = MagicMock()
+    mock_result.status_changes_applied = 0
+    mock_result.demotions_applied = 0
+    mock_result.reactor_updates = 0
+    mock_result.date_updates = 0
+    mock_result.warnings = []
+    mock_result.errors = ["Error applying status changes: boom"]
+
+    mock_svc = MagicMock()
+    mock_svc.preview_status_changes_from_excel.return_value = mock_preview
+    mock_svc.apply_status_changes.return_value = mock_result
+    fake_mod = MagicMock()
+    fake_mod.ExperimentStatusService = mock_svc
+
+    with patch.dict(sys.modules, {
+        "backend.services.bulk_uploads.experiment_status": fake_mod,
+    }):
+        resp = client.post(
+            "/api/bulk-uploads/experiment-status",
+            files={"file": ("status.xlsx", io.BytesIO(b"fake"), "application/vnd.ms-excel")},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    _assert_upload_shape(body)
+    assert "Error applying status changes: boom" in body["errors"]
+    assert body["updated"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Auth rejection tests (sample of endpoints)
 # ---------------------------------------------------------------------------

--- a/tests/services/bulk_uploads/test_experiment_status.py
+++ b/tests/services/bulk_uploads/test_experiment_status.py
@@ -173,3 +173,147 @@ def test_preview_serum_rows_same_reactor_do_not_conflict(db_session: Session):
 
     assert preview.errors == []
     assert len(preview.changes) == 2
+
+
+# ---------------------------------------------------------------------------
+# Reactor demotion planning (read-only — preview does not mutate the DB)
+# ---------------------------------------------------------------------------
+
+def test_preview_demotes_older_hpht_occupant_in_same_reactor(db_session: Session):
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST010", 6610, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=5, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST011", 6611, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST011", "ONGOING", 5, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert len(preview.demotions) == 1
+    assert preview.demotions[0].experiment_id == "HPHT_ST010"
+    assert preview.demotions[0].triggering_experiment_id == "HPHT_ST011"
+    assert any("HPHT_ST010" in w and "COMPLETED" in w for w in preview.warnings)
+
+
+def test_preview_demotes_older_core_flood_occupant_in_same_reactor(db_session: Session):
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "CF_ST001", 6612, ExperimentStatus.ONGOING, "Core Flood",
+        reactor_number=1, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "CF_ST002", 6613, ExperimentStatus.COMPLETED, "Core Flood")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["CF_ST002", "ONGOING", 1, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    demoted_ids = [d.experiment_id for d in preview.demotions]
+    assert "CF_ST001" in demoted_ids
+
+
+def test_preview_warns_no_demote_when_occupant_newer(db_session: Session):
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST012", 6614, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=6, date=datetime(2026, 6, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST013", 6615, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST013", "ONGOING", 6, "2026-01-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert preview.demotions == []
+    assert any("HPHT_ST012" in w for w in preview.warnings)
+
+
+def test_preview_warns_no_demote_when_occupant_equal_date(db_session: Session):
+    """Open Item #4: same-day → warn, do not demote."""
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST014", 6616, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=7, date=datetime(2026, 6, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST015", 6617, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST015", "ONGOING", 7, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert any("HPHT_ST014" in w for w in preview.warnings)
+
+
+def test_preview_warns_no_demote_when_incoming_date_missing(db_session: Session):
+    """Open Item #1: missing incoming date → don't demote, warn."""
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "HPHT_ST016", 6618, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=8, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "HPHT_ST017", 6619, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST017", "ONGOING", 8]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert any("HPHT_ST016" in w for w in preview.warnings)
+
+
+def test_preview_warns_no_demote_when_occupant_date_missing(db_session: Session):
+    """Open Item #1: missing occupant date → don't demote, warn."""
+    _seed_experiment(
+        db_session, "HPHT_ST018", 6620, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=9, date=None,
+    )
+    _seed_experiment(db_session, "HPHT_ST019", 6621, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST019", "ONGOING", 9, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert any("HPHT_ST018" in w for w in preview.warnings)
+
+
+def test_preview_serum_ongoing_with_reactor_no_demotion(db_session: Session):
+    """Non-occupancy types never trigger demotion, even if ONGOING with a reactor_number."""
+    from datetime import datetime
+
+    _seed_experiment(
+        db_session, "Serum_ST003", 6622, ExperimentStatus.ONGOING, "Serum",
+        reactor_number=10, date=datetime(2026, 1, 1),
+    )
+    _seed_experiment(db_session, "Serum_ST004", 6623, ExperimentStatus.COMPLETED, "Serum")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["Serum_ST004", "ONGOING", 10, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.demotions == []
+    assert preview.warnings == []

--- a/tests/services/bulk_uploads/test_experiment_status.py
+++ b/tests/services/bulk_uploads/test_experiment_status.py
@@ -1,9 +1,11 @@
 """Tests for ExperimentStatusService.
 
-Key logic:
-- to_ongoing: experiments listed in the file that exist in DB (reactor_number optional).
-- to_completed: ONGOING experiments with HPHT ExperimentalConditions NOT listed in the file.
-- missing_ids: listed experiment IDs not found in DB.
+Per-row model:
+- Each row sets its own `status` (ONGOING / COMPLETED / CANCELLED / QUEUED).
+- `reactor_number` and `date` are optional; `date` is the experiment start date.
+- Setting an HPHT or Core Flood row to ONGOING with a reactor_number schedules
+  demotion of an older ONGOING occupant in the same reactor (see Task 2 tests).
+- A missing `experiment_id` or `status` column hard-errors the whole upload.
 """
 from __future__ import annotations
 
@@ -28,20 +30,24 @@ def _seed_experiment(
     exp_num: int,
     status: ExperimentStatus = ExperimentStatus.ONGOING,
     experiment_type: str | None = None,
+    reactor_number: int | None = None,
+    date=None,
 ) -> Experiment:
     exp = Experiment(
         experiment_id=experiment_id,
         experiment_number=exp_num,
         status=status,
+        date=date,
     )
     db.add(exp)
     db.flush()
 
-    if experiment_type:
+    if experiment_type is not None or reactor_number is not None:
         cond = ExperimentalConditions(
             experiment_fk=exp.id,
             experiment_id=experiment_id,
             experiment_type=experiment_type,
+            reactor_number=reactor_number,
         )
         db.add(cond)
         db.flush()
@@ -50,137 +56,120 @@ def _seed_experiment(
 
 
 # ---------------------------------------------------------------------------
-# Preview tests
+# Column / row validation
 # ---------------------------------------------------------------------------
 
-def test_preview_places_listed_experiment_in_to_ongoing(db_session: Session):
-    """Any experiment listed in the file goes to to_ongoing (with or without reactor_number)."""
+def test_preview_missing_experiment_id_column_returns_error(db_session: Session):
+    xlsx = make_excel(["status", "reactor_number"], [["ONGOING", 3]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "experiment_id" in preview.errors[0]
+    assert preview.changes == []
+
+
+def test_preview_missing_status_column_returns_error(db_session: Session):
+    xlsx = make_excel(["experiment_id", "reactor_number"], [["HPHT_ST001", 3]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "status" in preview.errors[0]
+    assert preview.changes == []
+
+
+def test_preview_builds_planned_change_per_row(db_session: Session):
+    """A valid row produces one PlannedChange with the parsed status/reactor/date."""
     _seed_experiment(db_session, "HPHT_ST001", 6601, ExperimentStatus.COMPLETED, "HPHT")
 
     xlsx = make_excel(
-        ["experiment_id", "reactor_number"],
-        [["HPHT_ST001", 3]],
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST001", "ongoing", 3, "2026-07-15"]],
     )
     preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
 
     assert preview.errors == []
-    ongoing_ids = [r["experiment_id"] for r in preview.to_ongoing]
-    assert "HPHT_ST001" in ongoing_ids
-
-
-def test_preview_ongoing_hpht_not_in_file_goes_to_completed(db_session: Session):
-    """ONGOING HPHT experiment NOT in the file is auto-queued for COMPLETED."""
-    _seed_experiment(db_session, "HPHT_ST002", 6602, ExperimentStatus.ONGOING, "HPHT")
-    # Seed a different experiment in the file to trigger the completed-detection query
-    _seed_experiment(db_session, "HPHT_ST003", 6603, ExperimentStatus.COMPLETED, "HPHT")
-
-    xlsx = make_excel(
-        ["experiment_id", "reactor_number"],
-        [["HPHT_ST003", 2]],  # ST002 is NOT in the file
-    )
-    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
-
-    assert preview.errors == []
-    completed_ids = [r["experiment_id"] for r in preview.to_completed]
-    assert "HPHT_ST002" in completed_ids
+    assert len(preview.changes) == 1
+    change = preview.changes[0]
+    assert change.experiment_id == "HPHT_ST001"
+    assert change.new_status == "ONGOING"
+    assert change.new_reactor_number == 3
+    assert change.new_date is not None
+    assert change.new_date.date().isoformat() == "2026-07-15"
 
 
 def test_preview_records_missing_experiment_ids(db_session: Session):
-    """IDs not in the DB are captured in missing_ids."""
     xlsx = make_excel(
-        ["experiment_id", "reactor_number"],
-        [["NONEXISTENT_ST", 2]],
+        ["experiment_id", "status", "reactor_number"],
+        [["NONEXISTENT_ST", "ONGOING", 2]],
     )
     preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
-
     assert "NONEXISTENT_ST" in preview.missing_ids
-
-
-def test_preview_missing_experiment_id_column_returns_error(db_session: Session):
-    """File without 'experiment_id' column returns an error."""
-    xlsx = make_excel(
-        ["exp", "reactor"],
-        [["HPHT_ST001", 3]],
-    )
-    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
-
-    assert len(preview.errors) > 0
-
-
-# ---------------------------------------------------------------------------
-# Apply tests
-# ---------------------------------------------------------------------------
-
-def test_apply_marks_experiment_ongoing_with_reactor(db_session: Session):
-    """apply_status_changes transitions experiment to ONGOING."""
-    exp = _seed_experiment(db_session, "HPHT_ST004", 6604, ExperimentStatus.COMPLETED, "HPHT")
-
-    marked_ongoing, marked_completed, _reactor_updates, errors = (
-        ExperimentStatusService.apply_status_changes(
-            db_session, ["HPHT_ST004"], {}
-        )
-    )
-
-    assert errors == []
-    assert marked_ongoing == 1
-    db_session.refresh(exp)
-    assert exp.status == ExperimentStatus.ONGOING
-
-
-def test_apply_auto_completes_unlisted_ongoing_hpht(db_session: Session):
-    """apply_status_changes marks ONGOING HPHT experiments not in to_ongoing list as COMPLETED."""
-    exp_ongoing = _seed_experiment(
-        db_session, "HPHT_ST005", 6605, ExperimentStatus.ONGOING, "HPHT"
-    )
-    exp_listed = _seed_experiment(
-        db_session, "HPHT_ST006", 6606, ExperimentStatus.COMPLETED, "HPHT"
-    )
-
-    # Only ST006 is in to_ongoing; ST005 is ONGOING+HPHT and NOT listed → COMPLETED
-    marked_ongoing, marked_completed, _ru, errors = (
-        ExperimentStatusService.apply_status_changes(
-            db_session, ["HPHT_ST006"], {}
-        )
-    )
-
-    assert errors == []
-    assert marked_completed >= 1
-    db_session.flush()
-    db_session.refresh(exp_ongoing)
-    assert exp_ongoing.status == ExperimentStatus.COMPLETED
-
-
-def test_apply_empty_inputs_zero_changes(db_session: Session):
-    """apply_status_changes with empty to_ongoing and no ONGOING HPHT → zero changes."""
-    marked_ongoing, marked_completed, _ru, errors = (
-        ExperimentStatusService.apply_status_changes(db_session, [], {})
-    )
-    assert errors == []
-    assert marked_ongoing == 0
-
-
-def test_full_round_trip_file_to_db_state(db_session: Session):
-    """Full round-trip: file → preview → apply → DB state correct."""
-    exp_a = _seed_experiment(db_session, "HPHT_ST007", 6607, ExperimentStatus.COMPLETED, "HPHT")
-
-    xlsx = make_excel(
-        ["experiment_id", "reactor_number"],
-        [["HPHT_ST007", 5]],
-    )
-    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert preview.changes == []
     assert preview.errors == []
 
-    to_ongoing = [item["experiment_id"] for item in preview.to_ongoing]
-    reactor_map = {
-        item["experiment_id"]: item["new_reactor_number"]
-        for item in preview.to_ongoing
-        if item.get("new_reactor_number") is not None
-    }
-    marked_ongoing, _mc, _ru, errors = ExperimentStatusService.apply_status_changes(
-        db_session, to_ongoing, reactor_map
-    )
 
-    assert errors == []
-    assert marked_ongoing == 1
-    db_session.refresh(exp_a)
-    assert exp_a.status == ExperimentStatus.ONGOING
+def test_preview_invalid_status_produces_row_error(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST002", 6602, ExperimentStatus.ONGOING, "HPHT")
+    xlsx = make_excel(
+        ["experiment_id", "status"],
+        [["HPHT_ST002", "IN_PROGRESS"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "Invalid status" in preview.errors[0]
+
+
+def test_preview_invalid_reactor_number_produces_row_error(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST003", 6603, ExperimentStatus.ONGOING, "HPHT")
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST003", "ONGOING", "not-a-number"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "Invalid reactor_number" in preview.errors[0]
+
+
+def test_preview_invalid_date_produces_row_error(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST004", 6604, ExperimentStatus.ONGOING, "HPHT")
+    xlsx = make_excel(
+        ["experiment_id", "status", "date"],
+        [["HPHT_ST004", "ONGOING", "not-a-date"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert len(preview.errors) == 1
+    assert "Invalid date" in preview.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Same-reactor-in-file conflict (Open Item #3: error, don't let apply order decide)
+# ---------------------------------------------------------------------------
+
+def test_preview_same_reactor_multiple_rows_errors(db_session: Session):
+    _seed_experiment(db_session, "HPHT_ST005", 6605, ExperimentStatus.COMPLETED, "HPHT")
+    _seed_experiment(db_session, "HPHT_ST006", 6606, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST005", "ONGOING", 4], ["HPHT_ST006", "ONGOING", 4]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert len(preview.errors) == 1
+    assert "Reactor 4" in preview.errors[0]
+    assert "HPHT_ST005" in preview.errors[0]
+    assert "HPHT_ST006" in preview.errors[0]
+    assert preview.changes == []
+
+
+def test_preview_serum_rows_same_reactor_do_not_conflict(db_session: Session):
+    """The same-reactor conflict check only applies to HPHT/Core Flood rows."""
+    _seed_experiment(db_session, "Serum_ST001", 6607, ExperimentStatus.COMPLETED, "Serum")
+    _seed_experiment(db_session, "Serum_ST002", 6608, ExperimentStatus.COMPLETED, "Serum")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["Serum_ST001", "ONGOING", 4], ["Serum_ST002", "ONGOING", 4]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+
+    assert preview.errors == []
+    assert len(preview.changes) == 2

--- a/tests/services/bulk_uploads/test_experiment_status.py
+++ b/tests/services/bulk_uploads/test_experiment_status.py
@@ -407,3 +407,160 @@ def test_manage_reactor_occupancy_guard_warns_when_newer_than_is_none(db_session
     assert marked == 0
     db_session.refresh(occupant)
     assert occupant.status == ExperimentStatus.ONGOING
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "status,exp_num",
+    [("ONGOING", 6700), ("COMPLETED", 6701), ("CANCELLED", 6702), ("QUEUED", 6703)],
+)
+def test_apply_sets_each_status_value(db_session: Session, status: str, exp_num: int):
+    exp = _seed_experiment(db_session, f"HPHT_ST_{status}", exp_num, ExperimentStatus.ONGOING, "HPHT")
+
+    xlsx = make_excel(["experiment_id", "status"], [[exp.experiment_id, status]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert preview.errors == []
+
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.errors == []
+    assert result.status_changes_applied == 1
+    db_session.refresh(exp)
+    assert exp.status == ExperimentStatus(status)
+
+
+def test_apply_writes_date_when_provided(db_session: Session):
+    exp = _seed_experiment(db_session, "HPHT_ST030", 6640, ExperimentStatus.ONGOING, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "date"],
+        [["HPHT_ST030", "ONGOING", "2026-03-15"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.date_updates == 1
+    db_session.refresh(exp)
+    assert exp.date.date().isoformat() == "2026-03-15"
+
+
+def test_apply_leaves_date_untouched_when_absent(db_session: Session):
+    from datetime import datetime
+
+    exp = _seed_experiment(
+        db_session, "HPHT_ST031", 6641, ExperimentStatus.ONGOING, "HPHT", date=datetime(2026, 1, 1),
+    )
+
+    xlsx = make_excel(["experiment_id", "status"], [["HPHT_ST031", "COMPLETED"]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.date_updates == 0
+    db_session.refresh(exp)
+    assert exp.date.date().isoformat() == "2026-01-01"
+
+
+def test_apply_updates_reactor_number_when_provided(db_session: Session):
+    exp = _seed_experiment(
+        db_session, "HPHT_ST032", 6642, ExperimentStatus.ONGOING, "HPHT", reactor_number=1,
+    )
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ST032", "ONGOING", 9]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.reactor_updates == 1
+    db_session.refresh(exp)
+    assert exp.conditions.reactor_number == 9
+
+
+def test_apply_triggers_demotion_for_ongoing_hpht_with_older_occupant(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST033", 6643, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=15, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(db_session, "HPHT_ST034", 6644, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST034", "ONGOING", 15, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.demotions_applied == 1
+    db_session.refresh(occupant)
+    db_session.refresh(new_exp)
+    assert occupant.status == ExperimentStatus.COMPLETED
+    assert new_exp.status == ExperimentStatus.ONGOING
+
+
+def test_apply_no_demotion_for_serum_type_even_with_reactor_number(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "Serum_ST005", 6645, ExperimentStatus.ONGOING, "Serum",
+        reactor_number=16, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(db_session, "Serum_ST006", 6646, ExperimentStatus.COMPLETED, "Serum")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["Serum_ST006", "ONGOING", 16, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.demotions_applied == 0
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.ONGOING
+
+
+def test_apply_does_not_touch_unlisted_ongoing_experiment(db_session: Session):
+    """The retired 'complete every unlisted ongoing HPHT' behavior must not fire."""
+    unlisted = _seed_experiment(db_session, "HPHT_ST035", 6647, ExperimentStatus.ONGOING, "HPHT")
+    listed = _seed_experiment(db_session, "HPHT_ST036", 6648, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(["experiment_id", "status"], [["HPHT_ST036", "ONGOING"]])
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    db_session.refresh(unlisted)
+    assert unlisted.status == ExperimentStatus.ONGOING
+
+
+def test_full_round_trip_file_to_db_state(db_session: Session):
+    """Full round-trip: file → preview → apply → DB state correct, including a demotion."""
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST037", 6649, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=5, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(db_session, "HPHT_ST038", 6650, ExperimentStatus.COMPLETED, "HPHT")
+
+    xlsx = make_excel(
+        ["experiment_id", "status", "reactor_number", "date"],
+        [["HPHT_ST038", "ONGOING", 5, "2026-06-01"]],
+    )
+    preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
+    assert preview.errors == []
+
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+
+    assert result.errors == []
+    assert result.status_changes_applied == 1
+    assert result.demotions_applied == 1
+    db_session.refresh(new_exp)
+    db_session.refresh(occupant)
+    assert new_exp.status == ExperimentStatus.ONGOING
+    assert new_exp.date.date().isoformat() == "2026-06-01"
+    assert occupant.status == ExperimentStatus.COMPLETED

--- a/tests/services/bulk_uploads/test_experiment_status.py
+++ b/tests/services/bulk_uploads/test_experiment_status.py
@@ -342,6 +342,7 @@ def test_manage_reactor_occupancy_legacy_call_still_demotes_unconditionally(db_s
     )
 
     assert marked == 1
+    db_session.flush()
     db_session.refresh(occupant)
     assert occupant.status == ExperimentStatus.COMPLETED
     assert any("COMPLETED" in w for w in warnings)
@@ -364,6 +365,7 @@ def test_manage_reactor_occupancy_guard_demotes_older_occupant(db_session: Sessi
     )
 
     assert marked == 1
+    db_session.flush()
     db_session.refresh(occupant)
     assert occupant.status == ExperimentStatus.COMPLETED
 

--- a/tests/services/bulk_uploads/test_experiment_status.py
+++ b/tests/services/bulk_uploads/test_experiment_status.py
@@ -317,3 +317,91 @@ def test_preview_serum_ongoing_with_reactor_no_demotion(db_session: Session):
 
     assert preview.demotions == []
     assert preview.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# manage_reactor_occupancy — start-date guard
+# ---------------------------------------------------------------------------
+
+def test_manage_reactor_occupancy_legacy_call_still_demotes_unconditionally(db_session: Session):
+    """Regression: callers that don't pass newer_than (new_experiments.py, legacy create)
+    keep demoting regardless of start dates."""
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST020", 6624, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=11, date=datetime(2026, 12, 31),  # newer than the incoming experiment
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST021", 6625, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=11, date=datetime(2026, 1, 1),
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 11, commit=False,
+    )
+
+    assert marked == 1
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.COMPLETED
+    assert any("COMPLETED" in w for w in warnings)
+
+
+def test_manage_reactor_occupancy_guard_demotes_older_occupant(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST022", 6626, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=12, date=datetime(2026, 1, 1),
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST023", 6627, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=12, date=datetime(2026, 6, 1),
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 12, commit=False, newer_than=datetime(2026, 6, 1),
+    )
+
+    assert marked == 1
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.COMPLETED
+
+
+def test_manage_reactor_occupancy_guard_warns_on_newer_or_equal_occupant(db_session: Session):
+    from datetime import datetime
+
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST024", 6628, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=13, date=datetime(2026, 6, 1),
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST025", 6629, ExperimentStatus.ONGOING, "HPHT",
+        reactor_number=13, date=datetime(2026, 1, 1),
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 13, commit=False, newer_than=datetime(2026, 1, 1),
+    )
+
+    assert marked == 0
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.ONGOING
+    assert any("HPHT_ST024" in w and "HPHT_ST025" in w for w in warnings)
+
+
+def test_manage_reactor_occupancy_guard_warns_when_newer_than_is_none(db_session: Session):
+    occupant = _seed_experiment(
+        db_session, "HPHT_ST026", 6630, ExperimentStatus.ONGOING, "HPHT", reactor_number=14,
+    )
+    new_exp = _seed_experiment(
+        db_session, "HPHT_ST027", 6631, ExperimentStatus.ONGOING, "HPHT", reactor_number=14,
+    )
+
+    marked, warnings = ExperimentStatusService.manage_reactor_occupancy(
+        db_session, new_exp, 14, commit=False, newer_than=None,
+    )
+
+    assert marked == 0
+    db_session.refresh(occupant)
+    assert occupant.status == ExperimentStatus.ONGOING

--- a/tests/services/bulk_uploads/test_queued_status_upload.py
+++ b/tests/services/bulk_uploads/test_queued_status_upload.py
@@ -24,23 +24,19 @@ def _seed(db: Session, exp_id: str, num: int, status: ExperimentStatus, exp_type
 
 
 def test_bulk_status_upload_does_not_complete_queued(db_session: Session):
-    """A QUEUED HPHT experiment absent from the upload file must remain QUEUED."""
+    """A QUEUED HPHT experiment absent from the upload file must remain QUEUED (issue #33)."""
     queued_exp = _seed(db_session, "HPHT_QUEUED_001", 33010, ExperimentStatus.QUEUED, "HPHT")
     _seed(db_session, "HPHT_ACTIVE_001", 33011, ExperimentStatus.ONGOING, "HPHT")
 
     xlsx = make_excel(
-        ["experiment_id", "reactor_number"],
-        [["HPHT_ACTIVE_001", 1]],
+        ["experiment_id", "status", "reactor_number"],
+        [["HPHT_ACTIVE_001", "ONGOING", 1]],
     )
     preview = ExperimentStatusService.preview_status_changes_from_excel(db_session, xlsx)
     assert preview.errors == []
-    completed_ids = [r["experiment_id"] for r in preview.to_completed]
-    assert "HPHT_QUEUED_001" not in completed_ids
 
-    _ongoing, _completed, _ru, errors = ExperimentStatusService.apply_status_changes(
-        db_session, ["HPHT_ACTIVE_001"], {}
-    )
-    assert errors == []
+    result = ExperimentStatusService.apply_status_changes(db_session, preview)
+    assert result.errors == []
     db_session.refresh(queued_exp)
     assert queued_exp.status == ExperimentStatus.QUEUED, (
         "QUEUED experiment must not be auto-completed by bulk status upload"


### PR DESCRIPTION
## Summary
- Reworks the Experiment Status Update bulk upload from a whole-world "snapshot" model (forced ONGOING + blanket-complete unlisted HPHT) into an explicit per-row model: each row sets its own `status` (ONGOING/COMPLETED/CANCELLED/QUEUED), with optional `reactor_number` and `date`.
- Reactor demotion is now scoped to HPHT/Core-Flood-eligible ONGOING rows and gated on start date: an older same-reactor occupant is completed only if strictly older; newer-or-equal or missing dates produce a warning instead of a demotion. `manage_reactor_occupancy` gained an optional start-date guard while staying byte-identical for existing callers (`new_experiments.py`, legacy create path).
- Regenerated the download template (4 columns + INSTRUCTIONS sheet), updated the router endpoint and frontend tile copy, refreshed `docs/api/API_REFERENCE.md` / `docs/user_guide/BULK_UPLOADS.md` / `docs/upload_templates/experiment_status.md`, and updated the legacy Streamlit status-upload page to the new API shapes.
- Along the way, fixed a pre-existing broken test (`tests/services/bulk_uploads/test_queued_status_upload.py`, issue #33) that depended on the old API.
- No database migration — every field involved already existed.
- Four open items from the issue were explicitly confirmed with the user before implementation: missing dates → warn/don't demote; `status` column required (hard error if missing); duplicate same-reactor rows in one file → hard error; same-day dates → warn/don't demote.

## Test plan
- [x] Full backend suite: `pytest tests/ --ignore=tests/test_pg_backup_restore.py` → 743 passed, 4 skipped (pre-existing, unrelated), 0 failed
- [x] Full frontend suite: `npx vitest run src` → 47 passed
- [x] Each of the 8 implementation tasks individually task-reviewed (spec + quality) via subagent-driven-development, with fix/re-review loops where issues were found
- [x] Final whole-branch review (Opus) — approved with fixes; both Important findings (legacy Streamlit page, stale doc) resolved in a follow-up commit

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)