### PR TITLE
Hide empty conditions, round numeric values (#89)

### DIFF
--- a/docs/working/issue-log.md
+++ b/docs/working/issue-log.md
@@ -1138,3 +1138,11 @@ Test inserts `ExperimentalConditions(experiment_fk=1, ...)` but no `Experiment` 
 - **Files changed:** `frontend/src/pages/ExperimentDetail/GroupedResultsView.tsx` (metric useState default `gross_nh4` -> `h2_umol`); `frontend/src/pages/ExperimentDetail/__tests__/GroupedResultsView.test.tsx` (new test pinning default to H2 (umol))
 - **Tests added:** yes — one vitest assertion pinning the selector default (select value + visible option text). ExperimentDetail suite 32/32 pass; eslint clean
 - **Decision logged:** no
+
+## 2026-07-28 | issue #89 — Grouped experiment view: hide empty conditions and round numeric values
+- **Files changed:**
+  - `frontend/src/pages/ReplicateGroup/index.tsx` — `formatValue` now routes numbers through a new `formatNumber` helper (rounds to 3dp, trims trailing zeros); added `hasValue` and filtered the shared-conditions `.map` to skip null/undefined/empty entries before rendering, instead of rendering them as `—`
+  - `frontend/src/pages/ReplicateGroup/__tests__/ReplicateGroupPage.test.tsx` — 4 new tests: null shared-condition fields suppressed, long float rounds to 3dp, integer condition renders without trailing decimal, divergent field still renders label + "varies" text with its shared value absent
+- **Tests added:** yes — ReplicateGroupPage suite 11/11 pass; full frontend suite 101/101 pass; eslint clean
+- **Decision logged:** no — no shared numeric formatter extracted to `frontend/src/utils/` (issue's "consider extracting" was optional; `ConditionsTab.tsx`'s `Row` doesn't yet need it since `total_ferrous_iron_g` isn't rendered there)
+- **PR:** #91 → develop (open, not yet merged)

--- a/frontend/src/pages/ReplicateGroup/__tests__/ReplicateGroupPage.test.tsx
+++ b/frontend/src/pages/ReplicateGroup/__tests__/ReplicateGroupPage.test.tsx
@@ -142,4 +142,65 @@ describe('ReplicateGroupPage', () => {
     await waitFor(() => expect(experimentsApi.getGroup).toHaveBeenCalledWith('SERUM_001'))
     await waitFor(() => expect(experimentsApi.getGroupRollup).toHaveBeenCalledWith('SERUM_001'))
   })
+
+  it('does not render shared-condition labels whose value is null', async () => {
+    vi.mocked(experimentsApi.getGroup).mockResolvedValue({
+      ...ORPHAN_GROUP,
+      shared_conditions: {
+        experiment_type: 'Serum',
+        temperature_c: 90,
+        co2_partial_pressure_MPa: null,
+        confining_pressure: null,
+      },
+    })
+    renderAtBase('SERUM_001')
+
+    await waitFor(() => expect(screen.getByText('Temperature C:')).toBeInTheDocument())
+    expect(screen.queryByText('Co2 Partial Pressure MPa:')).not.toBeInTheDocument()
+    expect(screen.queryByText('Confining Pressure:')).not.toBeInTheDocument()
+  })
+
+  it('rounds a long float to 3 decimal places', async () => {
+    vi.mocked(experimentsApi.getGroup).mockResolvedValue({
+      ...ORPHAN_GROUP,
+      shared_conditions: {
+        ...ORPHAN_GROUP.shared_conditions,
+        total_ferrous_iron_g: 0.4088873141807,
+      },
+    })
+    renderAtBase('SERUM_001')
+
+    await waitFor(() => expect(screen.getByText('0.409')).toBeInTheDocument())
+  })
+
+  it('renders an integer-valued condition without a trailing decimal', async () => {
+    vi.mocked(experimentsApi.getGroup).mockResolvedValue({
+      ...ORPHAN_GROUP,
+      shared_conditions: {
+        ...ORPHAN_GROUP.shared_conditions,
+        temperature_c: 90,
+        initial_ph: 8,
+      },
+    })
+    renderAtBase('SERUM_001')
+
+    await waitFor(() => expect(screen.getByText('90')).toBeInTheDocument())
+    expect(screen.getByText('8')).toBeInTheDocument()
+    expect(screen.queryByText('90.000')).not.toBeInTheDocument()
+  })
+
+  it('still renders a divergent field label and the "varies" text when its shared value is absent', async () => {
+    vi.mocked(experimentsApi.getGroup).mockResolvedValue({
+      ...ORPHAN_GROUP,
+      divergent_fields: ['temperature_c'],
+      members: ORPHAN_GROUP.members.map((m, i) => ({
+        ...m,
+        conditions: { temperature_c: 60 + i },
+      })),
+    })
+    renderAtBase('SERUM_001')
+
+    await waitFor(() => expect(screen.getByText('Temperature C:')).toBeInTheDocument())
+    expect(screen.getByText('varies — see members table')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/ReplicateGroup/index.tsx
+++ b/frontend/src/pages/ReplicateGroup/index.tsx
@@ -35,8 +35,19 @@ function formatFieldName(field: string): string {
 function formatValue(value: unknown): string {
   if (value === null || value === undefined || value === '') return '—'
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (typeof value === 'number') return formatNumber(value)
   if (typeof value === 'object') return JSON.stringify(value)
   return String(value)
+}
+
+/** Rounds to 3 decimal places and trims trailing zeros (0.40888731418072486 -> "0.409", 90 -> "90"). */
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return String(value)
+  return parseFloat(value.toFixed(3)).toString()
+}
+
+function hasValue(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== ''
 }
 
 function isMemberDetail(
@@ -146,12 +157,14 @@ function ReplicateGroupContent({ group, baseId }: ReplicateGroupContentProps) {
         <CardHeader label="Conditions" />
         <CardBody>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-2">
-            {Object.entries(group.shared_conditions).map(([field, value]) => (
-              <div key={field} className="text-xs">
-                <span className="text-ink-muted">{formatFieldName(field)}: </span>
-                <span className="font-mono-data text-ink-primary">{formatValue(value)}</span>
-              </div>
-            ))}
+            {Object.entries(group.shared_conditions)
+              .filter(([, value]) => hasValue(value))
+              .map(([field, value]) => (
+                <div key={field} className="text-xs">
+                  <span className="text-ink-muted">{formatFieldName(field)}: </span>
+                  <span className="font-mono-data text-ink-primary">{formatValue(value)}</span>
+                </div>
+              ))}
             {group.divergent_fields.map((field) => (
               <div key={field} className="text-xs">
                 <span className="text-ink-muted">{formatFieldName(field)}: </span>


### PR DESCRIPTION
## Summary
- Shared-condition rows on the replicate group page (`/experiments/groups/{baseId}`) are now suppressed entirely when the value is `null`/`undefined`/`''`, matching `ConditionsTab`'s `Row` semantics, instead of rendering `Field Name: —`.
- Numeric values in that panel are now rounded to 3 decimal places with trailing zeros trimmed (e.g. `total_ferrous_iron_g` renders as `0.409` instead of `0.40888731418072486`; `90` and `8` render without trailing decimals).
- Divergent-field rendering (`varies — see members table`) and the `Additives:` footer are unchanged.

Closes #89.

## Test plan
- [x] `npx vitest run src/pages/ReplicateGroup/__tests__/ReplicateGroupPage.test.tsx` — 11/11 passing, including 4 new cases for null suppression, float rounding, integer formatting, and divergent-field behavior
- [x] `npx vitest run` (full suite) — 111/111 passing, no regressions
- [x] `npx eslint` on changed files — zero warnings/errors