### PR TITLE
[#88] Raise ink ramp contrast above WCAG AA

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -30,6 +30,20 @@
 
 ---
 
+## Text Hierarchy
+
+Three ink tiers, each guaranteed to clear WCAG AA (4.5:1) against all three navy surfaces (`surface.base` `#05172B`, `surface.raised` `#0a2440`, `surface.overlay` `#0e3158`). Tokens live in `frontend/src/assets/brand.ts` (source of truth), mirrored in `frontend/src/styles/tokens.css` and `frontend/tailwind.config.ts`; a vitest regression test (`frontend/src/test/contrast.test.ts`) enforces the AA floor and the tier ordering.
+
+| Token | Hex | On `base` | On `raised` | On `overlay` | Use for |
+|---|---|---|---|---|---|
+| `ink.primary` | `#F0F4F8` | 16.33:1 | 14.19:1 | 11.88:1 | Primary body/heading text |
+| `ink.secondary` | `#C5D9EA` | 12.45:1 | 10.82:1 | 9.06:1 | Secondary text, chart axis/legend labels |
+| `ink.muted` | `#A3C2DC` | 9.72:1 | 8.44:1 | 7.07:1 | Recessive labels — table `Th`, chart axis lines, unit/sub-labels |
+
+**AA floor:** every tier must clear 4.5:1 on every surface. Don't add a tier or change these hexes without recomputing contrast against all three surfaces.
+
+---
+
 ## Web App Usage
 
 - **Backgrounds:** `#05172B` for main/sidebar; slightly lighter tints for cards/panels if needed.

--- a/docs/project_context/DESIGN.md
+++ b/docs/project_context/DESIGN.md
@@ -30,6 +30,20 @@
 
 ---
 
+## Text Hierarchy
+
+Three ink tiers, each guaranteed to clear WCAG AA (4.5:1) against all three navy surfaces (`surface.base` `#05172B`, `surface.raised` `#0a2440`, `surface.overlay` `#0e3158`). Tokens live in `frontend/src/assets/brand.ts` (source of truth), mirrored in `frontend/src/styles/tokens.css` and `frontend/tailwind.config.ts`; a vitest regression test (`frontend/src/test/contrast.test.ts`) enforces the AA floor and the tier ordering.
+
+| Token | Hex | On `base` | On `raised` | On `overlay` | Use for |
+|---|---|---|---|---|---|
+| `ink.primary` | `#F0F4F8` | 16.33:1 | 14.19:1 | 11.88:1 | Primary body/heading text |
+| `ink.secondary` | `#C5D9EA` | 12.45:1 | 10.82:1 | 9.06:1 | Secondary text, chart axis/legend labels |
+| `ink.muted` | `#A3C2DC` | 9.72:1 | 8.44:1 | 7.07:1 | Recessive labels — table `Th`, chart axis lines, unit/sub-labels |
+
+**AA floor:** every tier must clear 4.5:1 on every surface. Don't add a tier or change these hexes without recomputing contrast against all three surfaces.
+
+---
+
 ## Web App Usage
 
 - **Backgrounds:** `#05172B` for main/sidebar; slightly lighter tints for cards/panels if needed.

--- a/docs/working/issue-log.md
+++ b/docs/working/issue-log.md
@@ -1138,3 +1138,15 @@ Test inserts `ExperimentalConditions(experiment_fk=1, ...)` but no `Experiment` 
 - **Files changed:** `frontend/src/pages/ExperimentDetail/GroupedResultsView.tsx` (metric useState default `gross_nh4` -> `h2_umol`); `frontend/src/pages/ExperimentDetail/__tests__/GroupedResultsView.test.tsx` (new test pinning default to H2 (umol))
 - **Tests added:** yes — one vitest assertion pinning the selector default (select value + visible option text). ExperimentDetail suite 32/32 pass; eslint clean
 - **Decision logged:** no
+
+## 2026-07-28 | issue #88 — Raise text contrast: shift the ink ramp up one step
+- **Files changed:**
+  - `frontend/src/styles/tokens.css` — `--color-ink-secondary` #8BACC8 → #C5D9EA; `--color-ink-muted` #4d6e8a → #A3C2DC
+  - `frontend/tailwind.config.ts` — `theme.extend.colors.ink.secondary`/`.muted` same values
+  - `frontend/src/assets/brand.ts` — `colors.inkSecondary`/`inkMuted` same values (source of truth)
+  - `frontend/src/test/contrast.test.ts` — NEW: WCAG luminance/contrast regression test, asserts inkPrimary/inkSecondary/inkMuted each clear 4.5:1 against navyBase/navyRaised/navyOverlay (imports live values from `brand.ts`) and asserts strict luminance ordering (primary > secondary > muted)
+  - `docs/DESIGN.md` (+ synced `docs/project_context/DESIGN.md`) — added a "Text Hierarchy" table (didn't previously exist) with hex values, per-surface contrast ratios, and the 4.5:1 AA floor note
+- **Deviation from issue spec:** `ink.muted` was raised past the issue's originally proposed #8BACC8 (5.52:1 on `overlay`) to #A3C2DC (7.07–9.72:1) after user feedback that the Th/hint-text tier was still hard to read in practice at the AA floor; re-verified AAA-level contrast on the worst-case surface while keeping `ink.muted` distinctly below `ink.secondary` (order preserved)
+- **Tests added:** yes — 10 new vitest assertions (3 tokens × 3 surfaces + ordering check), all passing; full frontend suite 107/107 pass; eslint clean
+- **Verification:** visually confirmed in Chrome (replicate group page, experiment detail Conditions/Results tabs, New Experiment form) — `Th` headers, condition labels, chevrons, and rollup chart axis/legend all legible and still read as chrome/secondary, not competing with data; no component-level color classes changed
+- **Decision logged:** no

--- a/frontend/src/assets/brand.ts
+++ b/frontend/src/assets/brand.ts
@@ -19,8 +19,8 @@ export const colors = {
 
   // Text
   inkPrimary:   '#F0F4F8',
-  inkSecondary: '#8BACC8',
-  inkMuted:     '#4d6e8a',
+  inkSecondary: '#C5D9EA',
+  inkMuted:     '#A3C2DC',
 
   // Status
   statusOngoing:   '#22c55e',

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -17,8 +17,8 @@
   --color-red-light: #ff6b5e;
 
   --color-ink-primary:   #F0F4F8;
-  --color-ink-secondary: #8BACC8;
-  --color-ink-muted:     #4d6e8a;
+  --color-ink-secondary: #C5D9EA;
+  --color-ink-muted:     #A3C2DC;
 
   --color-status-ongoing:   #22c55e;
   --color-status-completed: #38bdf8;

--- a/frontend/src/test/contrast.test.ts
+++ b/frontend/src/test/contrast.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { colors } from '../assets/brand'
+
+const AA_MIN_CONTRAST = 4.5
+
+function srgbToLinear(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(hex: string): number {
+  const value = hex.replace('#', '')
+  const r = parseInt(value.slice(0, 2), 16)
+  const g = parseInt(value.slice(2, 4), 16)
+  const b = parseInt(value.slice(4, 6), 16)
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b)
+}
+
+function contrastRatio(hexA: string, hexB: string): number {
+  const [lighter, darker] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort((a, b) => b - a)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+const inkTokens = {
+  inkPrimary: colors.inkPrimary,
+  inkSecondary: colors.inkSecondary,
+  inkMuted: colors.inkMuted,
+} as const
+
+const surfaces = {
+  navyBase: colors.navyBase,
+  navyRaised: colors.navyRaised,
+  navyOverlay: colors.navyOverlay,
+} as const
+
+describe('ink ramp contrast (issue #88)', () => {
+  for (const [tokenName, tokenHex] of Object.entries(inkTokens)) {
+    for (const [surfaceName, surfaceHex] of Object.entries(surfaces)) {
+      it(`${tokenName} clears AA (4.5:1) on ${surfaceName}`, () => {
+        expect(contrastRatio(tokenHex, surfaceHex)).toBeGreaterThanOrEqual(AA_MIN_CONTRAST)
+      })
+    }
+  }
+
+  it('keeps the three tiers strictly ordered by luminance (primary > secondary > muted)', () => {
+    const primaryLum = relativeLuminance(inkTokens.inkPrimary)
+    const secondaryLum = relativeLuminance(inkTokens.inkSecondary)
+    const mutedLum = relativeLuminance(inkTokens.inkMuted)
+
+    expect(primaryLum).toBeGreaterThan(secondaryLum)
+    expect(secondaryLum).toBeGreaterThan(mutedLum)
+  })
+})

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -33,8 +33,8 @@ export default {
         // Text hierarchy
         ink: {
           primary:   '#F0F4F8',
-          secondary: '#8BACC8',
-          muted:     '#4d6e8a',
+          secondary: '#C5D9EA',
+          muted:     '#A3C2DC',
           accent:    '#FD4437',
         },
         // Status colors


### PR DESCRIPTION
## Summary
- Shifts the ink text ramp brighter across all three token sites (`tokens.css`, `tailwind.config.ts`, `brand.ts`) so `ink.primary`/`ink.secondary`/`ink.muted` all clear 4.5:1 (AA) against `surface.base`/`surface.raised`/`surface.overlay`
- `ink.muted` was pushed further than the issue's original proposal (`#A3C2DC`, 7.07–9.72:1) after visual feedback that the AA-floor value still read as hard to read in the New Experiment form hint text and table `Th` headers
- No component-level color classes changed, per the issue's explicit scope

## Test plan
- [x] New `frontend/src/test/contrast.test.ts` — WCAG luminance/contrast regression test, 10 assertions (3 tokens × 3 surfaces + strict luminance ordering), reading live values from `brand.ts`
- [x] Full frontend suite: 107/107 pass
- [x] `eslint` clean on changed/new files
- [x] Visually verified in Chrome: replicate group page, experiment detail Conditions/Results tabs, New Experiment form — headers, condition labels, chevrons, and rollup chart axis/legend all legible and still read as chrome/secondary, not competing with data
- [x] `docs/DESIGN.md` updated with new hex values, per-surface contrast ratios, and the AA floor note

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)