### PR TITLE
[#92] Make results and rollup views H2-first

### DIFF
--- a/docs/project_context/REPLICATES.md
+++ b/docs/project_context/REPLICATES.md
@@ -38,15 +38,23 @@ The Experiments list has a **Group replicates** toggle (on by default). When on:
 On an experiment's **Results** tab, if the experiment belongs to a replicate set, a
 **Grouped (n=N)** mode appears alongside the normal per-vial view. It shows:
 
-- A chart of the selected metric (gross/net NH₄, NH₄ or H₂ g/t, H₂ µmol, Fe²⁺ yield, pH)
-  with the cross-replicate mean line and error bars (± 1 std) per timepoint, plus each
-  individual replicate's series overlaid (toggle-able) so you can spot an outlier vial.
+- A chart of the selected metric — **H₂ (ppm)** (the default), **H₂ (µmol)**, **H₂ (g/t)**,
+  **Fe²⁺ → H₂ (%)**, or **pH** — with the cross-replicate mean line and error bars (± 1 std)
+  per timepoint, plus each individual replicate's series overlaid (toggle-able) so you can
+  spot an outlier vial.
 - A table with the same mean/median/std/n columns per timepoint.
 - Click through from an individual series or table row to that replicate's own
   detail page to inspect its raw data.
 
 Individual series overlays are capped at 4 lines on the chart — in practice replicate
 sets are a/b/c, well under that cap.
+
+> **H₂-focused views.** Both the per-vial Results tab and the grouped rollup are
+> hydrogen-first: they show only H₂ metrics, Fe²⁺ → H₂ (%), pH, and conductivity. Ammonium
+> figures (gross/net NH₄, NH₄ g/t, Fe²⁺ → NH₃ (%)) are **not** deleted — they remain in the
+> database, the calculation engine, the `v_results_scalar_rollup` view, and the Power BI
+> datasets, and are still recorded through Bulk Uploads and the Add Results form. Only the
+> on-screen results and rollup tables dropped the NH₄ columns.
 
 ---
 

--- a/docs/project_context/USER_MANUAL.md
+++ b/docs/project_context/USER_MANUAL.md
@@ -40,7 +40,7 @@ Experiments move through a defined lifecycle from creation to completion:
 
 1. **Create** — Use the New Experiment form (`/experiments/new`) to record the basic metadata: experiment ID, researcher, date, and the associated sample.
 2. **Add Conditions** — Open the experiment's detail view and complete the Conditions tab: temperature, pH, reactor number, rock mass, water volume, and chemical additives.
-3. **Add Results** — Upload analytical data via Bulk Uploads (preferred for multiple experiments at once) or enter results manually on the Results tab of the experiment detail view.
+3. **Add Results** — Upload analytical data via Bulk Uploads (preferred for multiple experiments at once) or enter results manually on the Results tab of the experiment detail view. The Results tab and the grouped rollup **display** hydrogen metrics (H₂ ppm/µmol/g/t, Fe²⁺ → H₂ %, pH, conductivity); ammonium fields are still recorded and stored — they remain in the database and Power BI datasets — but are no longer shown in these two on-screen tables. See `REPLICATES.md` for details.
 4. **Analyze** — Use the Analysis tab to attach external analyses (XRD, pXRF, SEM, elemental) or view Aeris XRD time-series data.
 5. **Complete** — When the experiment is finished, change the status to **Completed** from the Dashboard or the experiment detail header. Cancelled experiments can be marked **Cancelled**.
 

--- a/docs/user_guide/REPLICATES.md
+++ b/docs/user_guide/REPLICATES.md
@@ -38,15 +38,23 @@ The Experiments list has a **Group replicates** toggle (on by default). When on:
 On an experiment's **Results** tab, if the experiment belongs to a replicate set, a
 **Grouped (n=N)** mode appears alongside the normal per-vial view. It shows:
 
-- A chart of the selected metric (gross/net NH₄, NH₄ or H₂ g/t, H₂ µmol, Fe²⁺ yield, pH)
-  with the cross-replicate mean line and error bars (± 1 std) per timepoint, plus each
-  individual replicate's series overlaid (toggle-able) so you can spot an outlier vial.
+- A chart of the selected metric — **H₂ (ppm)** (the default), **H₂ (µmol)**, **H₂ (g/t)**,
+  **Fe²⁺ → H₂ (%)**, or **pH** — with the cross-replicate mean line and error bars (± 1 std)
+  per timepoint, plus each individual replicate's series overlaid (toggle-able) so you can
+  spot an outlier vial.
 - A table with the same mean/median/std/n columns per timepoint.
 - Click through from an individual series or table row to that replicate's own
   detail page to inspect its raw data.
 
 Individual series overlays are capped at 4 lines on the chart — in practice replicate
 sets are a/b/c, well under that cap.
+
+> **H₂-focused views.** Both the per-vial Results tab and the grouped rollup are
+> hydrogen-first: they show only H₂ metrics, Fe²⁺ → H₂ (%), pH, and conductivity. Ammonium
+> figures (gross/net NH₄, NH₄ g/t, Fe²⁺ → NH₃ (%)) are **not** deleted — they remain in the
+> database, the calculation engine, the `v_results_scalar_rollup` view, and the Power BI
+> datasets, and are still recorded through Bulk Uploads and the Add Results form. Only the
+> on-screen results and rollup tables dropped the NH₄ columns.
 
 ---
 

--- a/docs/user_guide/USER_MANUAL.md
+++ b/docs/user_guide/USER_MANUAL.md
@@ -40,7 +40,7 @@ Experiments move through a defined lifecycle from creation to completion:
 
 1. **Create** — Use the New Experiment form (`/experiments/new`) to record the basic metadata: experiment ID, researcher, date, and the associated sample.
 2. **Add Conditions** — Open the experiment's detail view and complete the Conditions tab: temperature, pH, reactor number, rock mass, water volume, and chemical additives.
-3. **Add Results** — Upload analytical data via Bulk Uploads (preferred for multiple experiments at once) or enter results manually on the Results tab of the experiment detail view.
+3. **Add Results** — Upload analytical data via Bulk Uploads (preferred for multiple experiments at once) or enter results manually on the Results tab of the experiment detail view. The Results tab and the grouped rollup **display** hydrogen metrics (H₂ ppm/µmol/g/t, Fe²⁺ → H₂ %, pH, conductivity); ammonium fields are still recorded and stored — they remain in the database and Power BI datasets — but are no longer shown in these two on-screen tables. See `REPLICATES.md` for details.
 4. **Analyze** — Use the Analysis tab to attach external analyses (XRD, pXRF, SEM, elemental) or view Aeris XRD time-series data.
 5. **Complete** — When the experiment is finished, change the status to **Completed** from the Dashboard or the experiment detail header. Cancelled experiments can be marked **Cancelled**.
 

--- a/docs/working/issue-log.md
+++ b/docs/working/issue-log.md
@@ -1172,3 +1172,15 @@ Test inserts `ExperimentalConditions(experiment_fk=1, ...)` but no `Experiment` 
 - **Verification:** `alembic upgrade head` → both columns present on the view; `downgrade -1` → columns gone, view still queryable (1034 rows); re-`upgrade` clean.
 - **Decision logged:** no
 - **Lint note:** repo has no black/flake8 config; committed baseline already fails tool defaults (event_listeners flake8 111→115, all 4 new lines E501 on SQL matching the surrounding 20+ aggregate lines). New code matches surrounding style; not reformatted.
+
+## 2026-07-28 | issue #92 — H2-first results and rollup views: remove ammonium metrics from the frontend
+- **Depends on:** #90 (merged to develop via PR #94 before this branch was cut, so `r.h2_concentration` / `mean_h2_ppm` / `sd_h2_ppm` are available)
+- **Files changed:**
+  - `frontend/src/pages/ExperimentDetail/ResultsTab.tsx` — `GRID` template 13→11 tracks; per-result columns reordered H2-first (`★ · Time · Sample Date · H₂ ppm · H₂ µmol · H₂ g/t · Fe²⁺ H₂ % · pH · Cond. · ICP/XRD/MOD · ▾`); H₂ (ppm) reads `r.h2_concentration` from the existing `/results` payload (no per-row `getScalar`); removed the entire Background NH₄ affordance (button + inline input, `bgInput`/`bgValue` state, `storedBgValue`, `bgMutation`, `DEFAULT_BACKGROUND_NH4`, and the now-unused `useMutation`/`useQueryClient`/`queryClient`); dropped Gross NH₄ + Net NH₄ Yield from the `ExpandedRow` scalar list
+  - `frontend/src/pages/ExperimentDetail/GroupedResultsView.tsx` — `METRICS` trimmed from 8 to 5 (H₂ ppm/µmol/g/t, Fe²⁺→H₂ %, pH); default `metricKey` `h2_umol`→`h2_ppm`; rollup table columns → `Time · n · H₂ ppm · H₂ µmol · H₂ g/t · Fe²⁺→H₂ % · pH`, ppm at 1 dp with existing `mean ± sd` / `—` rendering
+  - `frontend/src/pages/ExperimentDetail/__tests__/ResultsTab.columns.test.tsx` — swapped Fe²⁺-NH₃ tests for: H₂ (ppm) header, H₂ (ppm) value from `/results`, no `NH₄` text anywhere, Background NH₄ button absent; kept Fe²⁺ H₂/XRD/MOD tests
+  - `frontend/src/pages/ExperimentDetail/__tests__/GroupedResultsView.test.tsx` — fixture `mean_h2_ppm`/`sd_h2_ppm` populated; default-selector test → H₂ (ppm); added exactly-five-options, no-NH₄-columnheader, and null-ppm→`—` tests
+  - `docs/user_guide/REPLICATES.md`, `docs/user_guide/USER_MANUAL.md` (+ auto-synced `docs/project_context/` copies) — noted results & rollup views are H2-focused and ammonium data remains in the DB, calc engine, `v_results_scalar_rollup`, and Power BI
+- **Backend/schema/view:** none — display-only change. Confirmed `v_results_scalar_rollup` still computes every ammonium aggregate (`mean_gross_ammonium_mM`, `sd_gross_ammonium_mM`, `mean_net_ammonium_mM`, `mean_fe_yield_nh3_pct`) unchanged in `database/event_listeners.py`
+- **Tests added:** yes — frontend only; affected suites 20/20, full frontend suite 116/116 pass; `tsc --noEmit` clean; eslint clean
+- **Decision logged:** no

--- a/frontend/src/pages/ExperimentDetail/GroupedResultsView.tsx
+++ b/frontend/src/pages/ExperimentDetail/GroupedResultsView.tsx
@@ -19,23 +19,14 @@ interface MetricDef {
 }
 
 const METRICS: MetricDef[] = [
-  { key: 'gross_nh4', label: 'Gross NH₄ (mM)', mean: 'mean_gross_ammonium_mM', sd: 'sd_gross_ammonium_mM',
-    individual: (r) => r.gross_ammonium_concentration_mM },
-  { key: 'net_nh4', label: 'Net NH₄ (mM)', mean: 'mean_net_ammonium_mM', sd: 'sd_net_ammonium_mM',
-    individual: (r) =>
-      r.gross_ammonium_concentration_mM != null && r.background_ammonium_concentration_mM != null
-        ? Math.max(0, r.gross_ammonium_concentration_mM - r.background_ammonium_concentration_mM)
-        : null },
-  { key: 'nh4_gpt', label: 'NH₄ (g/t)', mean: 'mean_grams_per_ton_yield', sd: 'sd_grams_per_ton_yield',
-    individual: (r) => r.grams_per_ton_yield },
+  { key: 'h2_ppm', label: 'H₂ (ppm)', mean: 'mean_h2_ppm', sd: 'sd_h2_ppm',
+    individual: (r) => r.h2_concentration },
   { key: 'h2_umol', label: 'H₂ (µmol)', mean: 'mean_h2_micromoles', sd: 'sd_h2_micromoles',
     individual: (r) => r.h2_micromoles },
   { key: 'h2_gpt', label: 'H₂ (g/t)', mean: 'mean_h2_grams_per_ton', sd: 'sd_h2_grams_per_ton',
     individual: (r) => r.h2_grams_per_ton_yield },
   { key: 'fe_h2', label: 'Fe²⁺ → H₂ (%)', mean: 'mean_fe_yield_h2_pct', sd: 'sd_fe_yield_h2_pct',
     individual: (r) => r.ferrous_iron_yield_h2_pct },
-  { key: 'fe_nh3', label: 'Fe²⁺ → NH₃ (%)', mean: 'mean_fe_yield_nh3_pct', sd: 'sd_fe_yield_nh3_pct',
-    individual: (r) => r.ferrous_iron_yield_nh3_pct },
   { key: 'ph', label: 'pH', mean: 'mean_final_ph', sd: null, individual: (r) => r.final_ph },
 ]
 
@@ -49,7 +40,7 @@ interface GroupedResultsViewProps {
 /** Base-level grouped results: mean ± std per timepoint from the rollup view,
  *  with individual replicate series overlay and drill-in links. */
 export function GroupedResultsView({ baseExperimentId }: GroupedResultsViewProps) {
-  const [metricKey, setMetricKey] = useState('h2_umol')
+  const [metricKey, setMetricKey] = useState('h2_ppm')
   const [showIndividual, setShowIndividual] = useState(true)
   const metric = METRICS.find((m) => m.key === metricKey)!
 
@@ -191,13 +182,10 @@ export function GroupedResultsView({ baseExperimentId }: GroupedResultsViewProps
           <tr>
             <Th>Time (d)</Th>
             <Th>n</Th>
-            <Th>Gross NH₄ (mM)</Th>
-            <Th>Net NH₄ (mM)</Th>
-            <Th>NH₄ (g/t)</Th>
+            <Th>H₂ (ppm)</Th>
             <Th>H₂ (µmol)</Th>
             <Th>H₂ (g/t)</Th>
             <Th>Fe²⁺ → H₂ (%)</Th>
-            <Th>Fe²⁺ → NH₃ (%)</Th>
             <Th>pH</Th>
           </tr>
         </TableHead>
@@ -207,19 +195,9 @@ export function GroupedResultsView({ baseExperimentId }: GroupedResultsViewProps
               <Td className="font-mono-data">{fmt(r.time_post_reaction_bucket_days, 1)}</Td>
               <Td className="font-mono-data text-ink-muted">n = {r.n_replicates}</Td>
               <Td className="font-mono-data">
-                {r.mean_gross_ammonium_mM == null
+                {r.mean_h2_ppm == null
                   ? '—'
-                  : `${fmt(r.mean_gross_ammonium_mM)} ± ${fmt(r.sd_gross_ammonium_mM ?? 0)}`}
-              </Td>
-              <Td className="font-mono-data">
-                {r.mean_net_ammonium_mM == null
-                  ? '—'
-                  : `${fmt(r.mean_net_ammonium_mM)} ± ${fmt(r.sd_net_ammonium_mM ?? 0)}`}
-              </Td>
-              <Td className="font-mono-data">
-                {r.mean_grams_per_ton_yield == null
-                  ? '—'
-                  : `${fmt(r.mean_grams_per_ton_yield, 1)} ± ${fmt(r.sd_grams_per_ton_yield ?? 0, 1)}`}
+                  : `${fmt(r.mean_h2_ppm, 1)} ± ${fmt(r.sd_h2_ppm ?? 0, 1)}`}
               </Td>
               <Td className="font-mono-data">
                 {r.mean_h2_micromoles == null
@@ -235,11 +213,6 @@ export function GroupedResultsView({ baseExperimentId }: GroupedResultsViewProps
                 {r.mean_fe_yield_h2_pct == null
                   ? '—'
                   : `${fmt(r.mean_fe_yield_h2_pct)} ± ${fmt(r.sd_fe_yield_h2_pct ?? 0)}`}
-              </Td>
-              <Td className="font-mono-data">
-                {r.mean_fe_yield_nh3_pct == null
-                  ? '—'
-                  : `${fmt(r.mean_fe_yield_nh3_pct)} ± ${fmt(r.sd_fe_yield_nh3_pct ?? 0)}`}
               </Td>
               <Td className="font-mono-data">{fmt(r.mean_final_ph)}</Td>
             </TableRow>

--- a/frontend/src/pages/ExperimentDetail/ResultsTab.tsx
+++ b/frontend/src/pages/ExperimentDetail/ResultsTab.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { experimentsApi, type ResultWithFlags } from '@/api/experiments'
 import { resultsApi } from '@/api/results'
 import { Badge, Button, PageSpinner } from '@/components/ui'
 import { AddResultsModal } from './AddResultsModal'
 import { GroupedResultsView } from './GroupedResultsView'
-
-const DEFAULT_BACKGROUND_NH4 = 0.2
 
 function fmt(n: number | null | undefined, decimals = 2) {
   return n != null ? n.toFixed(decimals) : '—'
@@ -21,7 +19,7 @@ function fmtPct(n: number | null | undefined, decimals = 1) {
   return n != null ? `${n.toFixed(decimals)}%` : '—'
 }
 
-const GRID = 'grid-cols-[1.5rem_5rem_6rem_5rem_5rem_4.5rem_5rem_5rem_4.5rem_4rem_6rem_9rem_1.5rem]'
+const GRID = 'grid-cols-[1.5rem_5rem_6rem_5rem_5rem_5rem_4.5rem_4rem_6rem_9rem_1.5rem]'
 
 function ExpandedRow({ result }: { result: ResultWithFlags }) {
   const { data: scalar, isLoading: loadingScalar } = useQuery({
@@ -47,8 +45,6 @@ function ExpandedRow({ result }: { result: ResultWithFlags }) {
             {[
               ['Final pH', scalar.final_ph, ''],
               ['Conductivity', scalar.final_conductivity_mS_cm, 'mS/cm'],
-              ['Gross NH₄', scalar.gross_ammonium_concentration_mM, 'mM'],
-              ['Net NH₄ Yield', scalar.grams_per_ton_yield, 'g/t'],
               ['H₂ (ppm)', scalar.h2_concentration, 'ppm'],
               ['H₂ (µmol)', scalar.h2_micromoles, 'µmol'],
               ['H₂ Yield', scalar.h2_grams_per_ton_yield, 'g/t'],
@@ -107,11 +103,8 @@ interface Props {
 /** Results tab: timepoint result cards with scalar chemistry and ICP data. */
 export function ResultsTab({ experimentId, experimentFk, idTimepointDays }: Props) {
   const [expanded, setExpanded] = useState<Set<number>>(new Set())
-  const [bgInput, setBgInput] = useState(false)
-  const [bgValue, setBgValue] = useState(String(DEFAULT_BACKGROUND_NH4))
   const [showAddModal, setShowAddModal] = useState(false)
   const [mode, setMode] = useState<'individual' | 'grouped'>('individual')
-  const queryClient = useQueryClient()
 
   const { data: replicateGroup } = useQuery({
     queryKey: ['replicate-group', experimentId],
@@ -122,21 +115,6 @@ export function ResultsTab({ experimentId, experimentFk, idTimepointDays }: Prop
   const { data: results, isLoading } = useQuery({
     queryKey: ['experiment-results', experimentId],
     queryFn: () => experimentsApi.getResults(experimentId),
-  })
-
-  // Derive the current background NH4 from the first result with a scalar value,
-  // falling back to the default. This reflects what is actually stored in the DB
-  // and stays correct after page reloads and after "Apply to all" refetches.
-  const storedBgValue = results?.find((r) => r.background_ammonium_concentration_mM != null)
-    ?.background_ammonium_concentration_mM ?? DEFAULT_BACKGROUND_NH4
-
-  const bgMutation = useMutation({
-    mutationFn: (value: number) => experimentsApi.setBackgroundAmmonium(experimentId, value),
-    onSuccess: () => {
-      setBgInput(false)
-      queryClient.invalidateQueries({ queryKey: ['experiment-results', experimentId] })
-      queryClient.invalidateQueries({ queryKey: ['scalar'] })
-    },
   })
 
   const toggle = (id: number) => setExpanded((s) => {
@@ -151,48 +129,7 @@ export function ResultsTab({ experimentId, experimentFk, idTimepointDays }: Prop
     <div>
       {/* Action bar */}
       <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-surface-border">
-        <div className="flex items-center gap-2">
-          {bgInput ? (
-            <>
-              <label className="text-xs text-ink-secondary">Background NH₄ (mM)</label>
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                value={bgValue}
-                onChange={(e) => setBgValue(e.target.value)}
-                className="w-20 text-xs px-2 py-1 border border-surface-border rounded bg-surface-raised text-ink-primary font-mono-data"
-                autoFocus
-              />
-              <button
-                onClick={() => {
-                  const parsed = parseFloat(bgValue)
-                  if (!isNaN(parsed) && parsed >= 0) bgMutation.mutate(parsed)
-                }}
-                disabled={bgMutation.isPending}
-                className="text-xs px-2 py-1 bg-navy-700 text-white rounded hover:bg-navy-600 disabled:opacity-50"
-              >
-                {bgMutation.isPending ? 'Applying…' : 'Apply to all'}
-              </button>
-              <button
-                onClick={() => setBgInput(false)}
-                className="text-xs px-2 py-1 text-ink-muted hover:text-ink-primary"
-              >
-                Cancel
-              </button>
-              {bgMutation.isError && (
-                <span className="text-xs text-red-500">Failed — try again</span>
-              )}
-            </>
-          ) : (
-            <button
-              onClick={() => { setBgValue(String(storedBgValue)); setBgInput(true) }}
-              className="text-xs text-ink-secondary hover:text-ink-primary underline-offset-2 hover:underline"
-            >
-              Background NH₄: {storedBgValue} mM
-            </button>
-          )}
-        </div>
+        <div />
         <div className="flex items-center gap-2">
           {hasGroup && (
             <div className="flex items-center rounded border border-surface-border overflow-hidden text-xs">
@@ -234,9 +171,7 @@ export function ResultsTab({ experimentId, experimentFk, idTimepointDays }: Prop
                 <span></span>
                 <span>Time (d)</span>
                 <span>Sample Date</span>
-                <span>Gross NH₄ (mM)</span>
-                <span>NH₄ (g/t)</span>
-                <span>Fe²⁺ NH₃ (%)</span>
+                <span>H₂ (ppm)</span>
                 <span>H₂ (µmol)</span>
                 <span>H₂ (g/t)</span>
                 <span>Fe²⁺ H₂ (%)</span>
@@ -254,9 +189,7 @@ export function ResultsTab({ experimentId, experimentFk, idTimepointDays }: Prop
                     <span className="text-xs text-ink-muted">{r.is_primary_timepoint_result ? '★' : ''}</span>
                     <span className="font-mono-data text-sm text-ink-primary">T+{r.time_post_reaction_days ?? '?'}</span>
                     <span className="font-mono-data text-xs text-ink-secondary">{fmtDate(r.scalar_measurement_date)}</span>
-                    <span className="font-mono-data text-xs text-ink-secondary">{fmt(r.gross_ammonium_concentration_mM)}</span>
-                    <span className="font-mono-data text-xs text-ink-secondary">{fmt(r.grams_per_ton_yield)}</span>
-                    <span className="font-mono-data text-xs text-ink-secondary">{fmtPct(r.ferrous_iron_yield_nh3_pct)}</span>
+                    <span className="font-mono-data text-xs text-ink-secondary">{fmt(r.h2_concentration, 1)}</span>
                     <span className="font-mono-data text-xs text-ink-secondary">{fmt(r.h2_micromoles)}</span>
                     <span className="font-mono-data text-xs text-ink-secondary">{fmt(r.h2_grams_per_ton_yield)}</span>
                     <span className="font-mono-data text-xs text-ink-secondary">{fmtPct(r.ferrous_iron_yield_h2_pct)}</span>

--- a/frontend/src/pages/ExperimentDetail/__tests__/GroupedResultsView.test.tsx
+++ b/frontend/src/pages/ExperimentDetail/__tests__/GroupedResultsView.test.tsx
@@ -32,7 +32,7 @@ const ROLLUP: RollupTimepoint[] = [
     base_experiment_id: 'SERUM_001', time_post_reaction_bucket_days: 7, n_replicates: 3,
     mean_gross_ammonium_mM: 2.0, median_gross_ammonium_mM: 2.0, sd_gross_ammonium_mM: 1.0,
     mean_net_ammonium_mM: 1.5, sd_net_ammonium_mM: 0.5,
-    mean_h2_ppm: null, sd_h2_ppm: null,
+    mean_h2_ppm: 500.0, sd_h2_ppm: 25.0,
     mean_h2_micromoles: null, sd_h2_micromoles: null,
     mean_h2_grams_per_ton: 12.3, sd_h2_grams_per_ton: 2.5,
     mean_fe_yield_h2_pct: 1.23, sd_fe_yield_h2_pct: 0.45,
@@ -76,10 +76,27 @@ describe('GroupedResultsView', () => {
     expect(experimentsApi.getGroupRollup).toHaveBeenCalledWith('SERUM_001')
   })
 
-  it('renders rollup stats table with mean ± sd and n', async () => {
+  it('renders mean_h2_ppm as mean ± sd with n', async () => {
     render(<GroupedResultsView baseExperimentId="SERUM_001" />, { wrapper })
     await waitFor(() => expect(screen.getByText(/n = 3/)).toBeInTheDocument())
-    expect(screen.getByText('2.00 ± 1.00')).toBeInTheDocument()
+    expect(screen.getByText('500.0 ± 25.0')).toBeInTheDocument()
+  })
+
+  it('renders — when mean_h2_ppm is null', async () => {
+    vi.mocked(experimentsApi.getGroupRollup).mockResolvedValue([
+      { ...ROLLUP[0], mean_h2_ppm: null, sd_h2_ppm: null },
+    ])
+    render(<GroupedResultsView baseExperimentId="SERUM_001" />, { wrapper })
+    await waitFor(() => expect(screen.getByText(/n = 3/)).toBeInTheDocument())
+    // Table columns: Time, n, H₂ (ppm), H₂ (µmol), H₂ (g/t), Fe²⁺ → H₂ (%), pH
+    const cells = screen.getAllByRole('cell')
+    expect(cells[2]).toHaveTextContent('—')
+  })
+
+  it('renders no NH₄ column headers in the rollup table', async () => {
+    render(<GroupedResultsView baseExperimentId="SERUM_001" />, { wrapper })
+    await waitFor(() => expect(screen.getByText(/n = 3/)).toBeInTheDocument())
+    expect(screen.queryByRole('columnheader', { name: /NH₄/ })).not.toBeInTheDocument()
   })
 
   it('links to each replicate page for drill-in', async () => {
@@ -90,12 +107,20 @@ describe('GroupedResultsView', () => {
     )
   })
 
-  it('defaults the metric selector to H₂ (µmol)', async () => {
+  it('defaults the metric selector to H₂ (ppm)', async () => {
     render(<GroupedResultsView baseExperimentId="SERUM_001" />, { wrapper })
     await waitFor(() => expect(screen.getByText(/n = 3/)).toBeInTheDocument())
     const select = screen.getByLabelText(/metric/i) as HTMLSelectElement
-    expect(select.value).toBe('h2_umol')
-    expect(select.options[select.selectedIndex].text).toBe('H₂ (µmol)')
+    expect(select.value).toBe('h2_ppm')
+    expect(select.options[select.selectedIndex].text).toBe('H₂ (ppm)')
+  })
+
+  it('lists exactly the five H₂-first metric options', async () => {
+    render(<GroupedResultsView baseExperimentId="SERUM_001" />, { wrapper })
+    await waitFor(() => expect(screen.getByText(/n = 3/)).toBeInTheDocument())
+    const select = screen.getByLabelText(/metric/i) as HTMLSelectElement
+    const texts = Array.from(select.options).map((o) => o.text)
+    expect(texts).toEqual(['H₂ (ppm)', 'H₂ (µmol)', 'H₂ (g/t)', 'Fe²⁺ → H₂ (%)', 'pH'])
   })
 
   it('changes plotted metric via the selector', async () => {

--- a/frontend/src/pages/ExperimentDetail/__tests__/ResultsTab.columns.test.tsx
+++ b/frontend/src/pages/ExperimentDetail/__tests__/ResultsTab.columns.test.tsx
@@ -54,25 +54,41 @@ const baseResult: ResultWithFlags = {
   xrd_run_date: null,
 }
 
-describe('ResultsTab — new columns', () => {
-  it('renders Fe²⁺ NH₃ (%) column header', async () => {
+describe('ResultsTab — H2-first columns', () => {
+  it('renders the H₂ (ppm) column header', async () => {
     vi.mocked(experimentsApiModule.experimentsApi.getResults).mockResolvedValue([baseResult])
     wrap(<ResultsTab experimentId="HPHT_001" experimentFk={10} />)
-    expect(await screen.findByText('Fe²⁺ NH₃ (%)')).toBeInTheDocument()
+    expect(await screen.findByText('H₂ (ppm)')).toBeInTheDocument()
+  })
+
+  it('renders the H₂ (ppm) value from the /results payload', async () => {
+    vi.mocked(experimentsApiModule.experimentsApi.getResults).mockResolvedValue([
+      { ...baseResult, h2_concentration: 512 },
+    ])
+    wrap(<ResultsTab experimentId="HPHT_001" experimentFk={10} />)
+    expect(await screen.findByText('512.0')).toBeInTheDocument()
+  })
+
+  it('renders no NH₄ text anywhere in the table', async () => {
+    vi.mocked(experimentsApiModule.experimentsApi.getResults).mockResolvedValue([
+      { ...baseResult, gross_ammonium_concentration_mM: 3.2, ferrous_iron_yield_nh3_pct: 24.6 },
+    ])
+    wrap(<ResultsTab experimentId="HPHT_001" experimentFk={10} />)
+    await screen.findByText('T+7')
+    expect(screen.queryByText(/NH₄/)).not.toBeInTheDocument()
+  })
+
+  it('does not render the Background NH₄ action-bar button', async () => {
+    vi.mocked(experimentsApiModule.experimentsApi.getResults).mockResolvedValue([baseResult])
+    wrap(<ResultsTab experimentId="HPHT_001" experimentFk={10} />)
+    await screen.findByText('T+7')
+    expect(screen.queryByText(/Background NH₄/)).not.toBeInTheDocument()
   })
 
   it('renders Fe²⁺ H₂ (%) column header', async () => {
     vi.mocked(experimentsApiModule.experimentsApi.getResults).mockResolvedValue([baseResult])
     wrap(<ResultsTab experimentId="HPHT_001" experimentFk={10} />)
     expect(await screen.findByText('Fe²⁺ H₂ (%)')).toBeInTheDocument()
-  })
-
-  it('renders 24.6% for ferrous_iron_yield_nh3_pct = 24.6', async () => {
-    vi.mocked(experimentsApiModule.experimentsApi.getResults).mockResolvedValue([
-      { ...baseResult, ferrous_iron_yield_nh3_pct: 24.6 },
-    ])
-    wrap(<ResultsTab experimentId="HPHT_001" experimentFk={10} />)
-    expect(await screen.findByText('24.6%')).toBeInTheDocument()
   })
 
   it('renders 16.8% for ferrous_iron_yield_h2_pct = 16.8', async () => {


### PR DESCRIPTION
Closes #92.

Display-only frontend change: reorder the per-result Results table and the grouped rollup to lead with hydrogen, and remove the on-screen ammonium metrics. All ammonium data remains in the schema, calculation engine, `v_results_scalar_rollup`, and Power BI datasets, and is still recorded via Bulk Uploads and the Add Results form.

## Changes
- **`ResultsTab.tsx`** — `GRID` 13→11 tracks; columns `★ · Time · Sample Date · H₂ ppm · H₂ µmol · H₂ g/t · Fe²⁺ H₂ % · pH · Cond. · ICP/XRD/MOD · ▾`. H₂ (ppm) reads `r.h2_concentration` from the existing `/results` request (no per-row `getScalar`). Removed the Background NH₄ affordance entirely (button, input, state, `bgMutation`, `DEFAULT_BACKGROUND_NH4`, now-unused hooks) and the two NH₄ rows in the expanded drawer. `experimentsApi.setBackgroundAmmonium` and the backend endpoint are left in place.
- **`GroupedResultsView.tsx`** — `METRICS` trimmed to five (H₂ ppm/µmol/g/t, Fe²⁺→H₂ %, pH); default metric `h2_umol`→`h2_ppm`; rollup table columns reshaped, ppm at 1 dp.
- Tests + `REPLICATES.md` / `USER_MANUAL.md` updated.

## Verification
- `tsc --noEmit` clean; `eslint` clean
- Full frontend vitest suite: 23 files, 116 tests pass
- Confirmed `v_results_scalar_rollup` still computes every ammonium aggregate (unchanged in `event_listeners.py`)

Depends on #90 (already merged to develop via #94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)